### PR TITLE
Enhance media SQL migration with security policies

### DIFF
--- a/supabase/migrations/20260513193300_media.sql
+++ b/supabase/migrations/20260513193300_media.sql
@@ -1,26 +1,37 @@
+
 create table public.media_assets (
   id uuid primary key default gen_random_uuid(),
-  -- Storage bucket key, NOT the public URL
   storage_key text not null unique,
   uploaded_by uuid references public.profiles (id) on delete set null,
   created_at timestamptz not null default now()
 );
 
--- Many-to-many between revisions and assets, written when a revision is saved
 create table public.revision_assets (
   revision_id uuid not null references public.guide_revisions (id) on delete cascade,
   asset_id uuid not null references public.media_assets (id) on delete cascade,
   primary key (revision_id, asset_id)
 );
 
--- Reverse lookup: "which revisions still reference this asset?"
 create index revision_assets_asset_id_idx on public.revision_assets (asset_id);
 
--- Storage bucket backing media_assets.storage_key
-insert into storage.buckets (id, name, public)
-values ('media', 'media', true);
 
--- Row-level security policies
+insert into storage.buckets (id, name, public)
+values ('media', 'media', true)
+on conflict (id) do nothing; -- to prevent dupe error
+
+-- 3. Storage Security Fix
+alter table storage.objects enable row level security;
+
+create policy "Media bucket files are public"
+  on storage.objects for select
+  using (bucket_id = 'media');
+
+create policy "Users can upload files to media bucket"
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'media' and auth.uid() = owner);
+
+-- 4. Table row level
 alter table public.media_assets enable row level security;
 alter table public.revision_assets enable row level security;
 
@@ -31,7 +42,7 @@ create policy "Media assets are viewable by everyone"
 create policy "Authenticated users can upload their own media"
   on public.media_assets for insert
   to authenticated
-  with check (uploaded_by = (select auth.uid()));
+  with check (uploaded_by = auth.uid());
 
 create policy "Revision asset links are viewable by everyone"
   on public.revision_assets for select
@@ -44,7 +55,7 @@ create policy "Revision authors can link assets to their draft revisions"
     exists (
       select 1 from public.guide_revisions r
       where r.id = revision_id
-        and r.author_id = (select auth.uid())
+        and r.author_id = auth.uid()
         and r.status = 'draft'
     )
   );

--- a/supabase/migrations/20260613193500_fix_storage_policies.sql
+++ b/supabase/migrations/20260613193500_fix_storage_policies.sql
@@ -1,0 +1,63 @@
+create table public.media_assets (
+  id uuid primary key default gen_random_uuid(),
+  -- Storage bucket key, NOT the public URL
+  storage_key text not null unique,
+  uploaded_by uuid references public.profiles (id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+-- Many-to-many between revisions and assets, written when a revision is saved
+create table public.revision_assets (
+  revision_id uuid not null references public.guide_revisions (id) on delete cascade,
+  asset_id uuid not null references public.media_assets (id) on delete cascade,
+  primary key (revision_id, asset_id)
+);
+
+
+create index revision_assets_asset_id_idx on public.revision_assets (asset_id);
+
+-- Storage bucket backing media_assets.storage_key
+insert into storage.buckets (id, name, public)
+values ('media', 'media', true)
+on conflict (id) do nothing;
+
+
+alter table storage.objects enable row level security;
+
+create policy "Media bucket files are public"
+  on storage.objects for select
+  using (bucket_id = 'media');
+
+create policy "Users can upload files to media bucket"
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'media' and auth.uid() = owner);
+
+-- Row-level security policies
+alter table public.media_assets enable row level security;
+alter table public.revision_assets enable row level security;
+
+create policy "Media assets are viewable by everyone"
+  on public.media_assets for select
+  using (true);
+
+create policy "Authenticated users can upload their own media"
+  on public.media_assets for insert
+  to authenticated
+  with check (uploaded_by = (select auth.uid()));
+
+create policy "Revision asset links are viewable by everyone"
+  on public.revision_assets for select
+  using (true);
+
+create policy "Revision authors can link assets to their draft revisions"
+  on public.revision_assets for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.guide_revisions r
+      where r.id = revision_id
+        and r.author_id = (select auth.uid())
+        and r.status = 'draft'
+    )
+  );


### PR DESCRIPTION
Updated SQL migration to include row-level security policies for media assets and revisions, and fixed syntax for user checks.



## Summary



## Related issues



## Type of change

- Bug fix
- Feature
- Refactor (no behavior change)
- Documentation
- Build / tooling / CI
- Other:

## How was this tested?



## Checklist

- `pnpm -r typecheck` passes
- `pnpm -r build` passes
- Manually verified in a browser (for UI / behavior changes)
- Followed the app layout conventions
- No new dependencies, or new dependencies justified in the
description and licenses are AGPL-compatible
- Change does not violate any non-negotiable principle

