### PR TITLE
feat: update guide view

### DIFF
--- a/app/src/components/CollapsibleSection.tsx
+++ b/app/src/components/CollapsibleSection.tsx
@@ -1,4 +1,11 @@
-import { ChevronDown } from "lucide-react"
+import { useState } from "react"
+import { ChevronRight } from "lucide-react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 
 export const CollapsibleSection = ({
   title,
@@ -7,13 +14,24 @@ export const CollapsibleSection = ({
   title: string
   children: React.ReactNode
 }) => {
+  const [open, setOpen] = useState(false)
+
   return (
-    <details className="group border-b py-4">
-      <summary className="flex cursor-pointer list-none items-center justify-between data-label">
-        {title}
-        <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
-      </summary>
-      <div className="mt-4 space-y-2 text-sm">{children}</div>
-    </details>
+    <Collapsible open={open} onOpenChange={setOpen} className="border-b py-4 group">
+      <CollapsibleTrigger asChild>
+        <button className="flex w-full cursor-pointer list-none items-center justify-between data-label">
+          <ChevronRight
+            className={`h-4 w-4 transition-transform ${
+              open ? "rotate-90" : ""
+            }`}
+          />
+          {title}
+        </button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="mt-4 space-y-2 text-sm">
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
   )
 }

--- a/app/src/components/ui/collapsible.tsx
+++ b/app/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/app/src/data/guides.json
+++ b/app/src/data/guides.json
@@ -238,7 +238,7 @@
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
-      "game development",
+      "game-development",
       "ai"
     ],
     "breadcrumbs": [

--- a/app/src/data/guides.json
+++ b/app/src/data/guides.json
@@ -234,7 +234,7 @@
     "slug": "game-ai-systems-how-to-build-ai-behaviours",
     "title": "How to Build Game AI Behaviours",
     "author": "bluelearn",
-    "summary": "Understand common data structures and learn when to use each one effectively.",
+    "summary": "Understand game AI systems and how to develop custom AI behviours.",
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
@@ -256,7 +256,7 @@
     "slug": "game-development-introduction",
     "title": "Introduction to Game Development",
     "author": "bluelearn",
-    "summary": "Understand common data structures and learn when to use each one effectively.",
+    "summary": "Learn how to create and animate game characters and bring them into Unity.",
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
@@ -276,7 +276,7 @@
     "slug": "blender-character-creation",
     "title": "Blender Character Creation",
     "author": "bluelearn",
-    "summary": "Understand common data structures and learn when to use each one effectively.",
+    "summary": "Learn how to create characters in blender starting with the initial sketch to the 3D character.",
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
@@ -292,7 +292,7 @@
     "prerequisites": [
       "basic-3d-modelling"
     ],
-    "content": "# Starting with the Base Mesh"
+    "content": "# Starting with the character concept sketch"
   },
   {
     "slug": "unity-import-character",

--- a/app/src/data/guides.json
+++ b/app/src/data/guides.json
@@ -155,7 +155,7 @@
     "duration": 15,
     "tags": [
       "ai",
-      "machine learning"
+      "machine-learning"
     ],
     "breadcrumbs": [
       "Home",
@@ -199,7 +199,7 @@
     "duration": 15,
     "tags": [
       "programming",
-      "computer science"
+      "computer-science"
     ],
     "breadcrumbs": [
       "Home",
@@ -217,8 +217,8 @@
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
-      "computer science",
-      "data structures"
+      "computer-science",
+      "data-structures"
     ],
     "breadcrumbs": [
       "Home",
@@ -260,7 +260,7 @@
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
-      "game development"
+      "game-development"
     ],
     "breadcrumbs": [
       "Home",
@@ -302,7 +302,7 @@
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
-      "game development",
+      "game-development",
       "unity",
       "3d"
     ],
@@ -324,7 +324,7 @@
     "created_at": "14th June 2026",
     "duration": 15,
     "tags": [
-      "game development",
+      "game-development",
       "unity",
       "programming"
     ],

--- a/app/src/data/paths.json
+++ b/app/src/data/paths.json
@@ -6,6 +6,9 @@
     "curator": "bluelearn",
     "created_at": "14th June 2026",
     "duration": 720,
+    "tags": [
+      "game-development"
+    ],
     "levels": [
       {
         "level": 1,

--- a/app/src/data/subjects.json
+++ b/app/src/data/subjects.json
@@ -9,6 +9,15 @@
     "languages_total": 12
   },
   {
+    "slug": "ai",
+    "name": "AI",
+    "summary": "Guides covering Artificial Intelligence (AI), Machine Learning (ML) and Deep Learning.",
+    "paths_total": 5,
+    "guides_total": 142,
+    "contributors_total": 38,
+    "languages_total": 12
+  },
+  {
     "slug": "archery",
     "name": "Archery",
     "summary": "Guides on learning archery, including bow handling, shooting techniques, aiming accuracy, form, and target practice fundamentals.",

--- a/app/src/data/subjects.json
+++ b/app/src/data/subjects.json
@@ -214,5 +214,122 @@
     "guides_total": 149,
     "contributors_total": 37,
     "languages_total": 12
+  },
+  {
+    "slug": "probability",
+    "name": "Probability",
+    "summary": "Guides covering probability theory, random events, likelihood calculations, probability distributions, and reasoning under uncertainty.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "statistics",
+    "name": "Statistics",
+    "summary": "Guides covering data collection, analysis, interpretation, visualisation, statistical testing, and drawing conclusions from data.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "vectors",
+    "name": "Vectors",
+    "summary": "Guides covering vector mathematics, magnitude, direction, vector operations, coordinate systems, and applications in science and engineering.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "physics",
+    "name": "Physics",
+    "summary": "Guides covering the fundamental laws of nature, including motion, forces, energy, matter, waves, electricity, and modern physics.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "mechanics",
+    "name": "Mechanics",
+    "summary": "Guides covering motion, forces, momentum, energy, statics, dynamics, and the behaviour of physical systems.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "machine-learning",
+    "name": "Machine Learning",
+    "summary": "Guides covering supervised and unsupervised learning, model training, feature engineering, evaluation techniques, and practical machine learning systems.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "simulation",
+    "name": "Simulation",
+    "summary": "Guides covering the creation of simulations, modelling real-world systems, numerical methods, and virtual experimentation.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "computer-science",
+    "name": "Computer Science",
+    "summary": "Guides covering algorithms, computation, software systems, data structures, programming principles, and theoretical foundations of computing.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "data-structures",
+    "name": "Data Structures",
+    "summary": "Guides covering arrays, linked lists, stacks, queues, trees, graphs, hash tables, and efficient data organisation techniques.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "3d-modelling",
+    "name": "3D Modelling",
+    "summary": "Guides covering the creation of three-dimensional assets, including modelling techniques, topology, sculpting, texturing, and optimisation.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "blender",
+    "name": "Blender",
+    "summary": "Guides covering the Blender software suite, including modelling, sculpting, animation, rendering, compositing, and asset creation workflows.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "animation",
+    "name": "Animation",
+    "summary": "Guides covering animation principles, character movement, rigging, keyframing, motion workflows, and visual storytelling.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
+  },
+  {
+    "slug": "3d",
+    "name": "3D",
+    "summary": "Guides covering three-dimensional graphics, environments, assets, rendering techniques, and interactive 3D applications.",
+    "paths_total": 5,
+    "guides_total": 0,
+    "contributors_total": 0,
+    "languages_total": 0
   }
 ]

--- a/app/src/lib/getData.ts
+++ b/app/src/lib/getData.ts
@@ -1,6 +1,24 @@
-import type { Guide } from "@/types/guides"
+import type { Subject, SubjectReference } from "@/types/subjects";
+import type {
+  Guide,
+  GuideReference,
+  HydratedGuide,
+} from "@/types/guides";
 import type { HydratedPath, Path } from "@/types/paths"
 
+// TODO: update to fetch from api
+export const getPathBySlug = (paths: Array<Path>, slug: string) => {
+  const foundPath = paths.find(path => path.slug === slug);
+  return foundPath;
+}
+
+// TODO: update to fetch from api
+export const getGuideBySlug = (guides: Array<Guide>, slug: string) => {
+  const foundGuide = guides.find(guide => guide.slug === slug);
+  return foundGuide;
+}
+
+// TODO: used for hydration - remove when fetching from api
 export const createGuideMap = (guides: Array<Guide>): Record<string, Guide> => {
   const guideMap = guides.reduce<Record<string, Guide>>((acc, guide) => {
     acc[guide.slug] = guide;
@@ -10,6 +28,21 @@ export const createGuideMap = (guides: Array<Guide>): Record<string, Guide> => {
   return guideMap;
 }
 
+export const createSubjectMap = (
+  subjects: Subject[]
+): Record<string, Subject> => {
+  const subjectMap = subjects.reduce<Record<string, Subject>>(
+    (acc, subject) => {
+      acc[subject.slug] = subject;
+      return acc;
+    },
+    {}
+  );
+
+  return subjectMap;
+};
+
+// TODO: when integrating api hydration should be done on the backend - change this to fetch from api
 export const hydratePaths = (guides: Array<Guide>, paths: Array<Path>): Array<HydratedPath> => {
   const guideMap = createGuideMap(guides);
 
@@ -24,12 +57,32 @@ export const hydratePaths = (guides: Array<Guide>, paths: Array<Path>): Array<Hy
   return hydratedPaths
 }
 
-export const getPathBySlug = (paths: Array<Path>, slug: string) => {
-  const foundPath = paths.find(path => path.slug === slug);
-  return foundPath;
-}
 
-export const getGuideBySlug = (guides: Array<Guide>, slug: string) => {
-  const foundGuide = guides.find(guide => guide.slug === slug);
-  return foundGuide;
-}
+export const hydrateGuide = (
+  guide: Guide,
+  guides: Array<Guide>,
+  subjects: Array<Subject>
+): HydratedGuide => {
+  const guideMap = createGuideMap(guides);
+  const subjectMap = createSubjectMap(subjects);
+
+  return {
+    ...guide,
+
+    tags: guide.tags
+      .map((slug) => subjectMap[slug])
+      .filter((subject): subject is Subject => !!subject)
+      .map<SubjectReference>((subject) => ({
+        slug: subjectMap[subject.slug].slug,
+        name: subjectMap[subject.slug].name
+      })),
+
+    prerequisites: guide.prerequisites
+      .map((slug) => guideMap[slug])
+      .filter((guide): guide is Guide => !!guide)
+      .map<GuideReference>((guide) => ({
+        slug: guide.slug,
+        title: guide.title,
+      })),
+  };
+};

--- a/app/src/lib/getData.ts
+++ b/app/src/lib/getData.ts
@@ -28,3 +28,8 @@ export const getPathBySlug = (paths: Array<Path>, slug: string) => {
   const foundPath = paths.find(path => path.slug === slug);
   return foundPath;
 }
+
+export const getGuideBySlug = (guides: Array<Guide>, slug: string) => {
+  const foundGuide = guides.find(guide => guide.slug === slug);
+  return foundGuide;
+}

--- a/app/src/lib/getData.ts
+++ b/app/src/lib/getData.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/types/guides";
 import type { HydratedPath, Path } from "@/types/paths"
 
+
 // TODO: update to fetch from api
 export const getPathBySlug = (paths: Array<Path>, slug: string) => {
   const foundPath = paths.find(path => path.slug === slug);
@@ -29,7 +30,7 @@ export const createGuideMap = (guides: Array<Guide>): Record<string, Guide> => {
 }
 
 export const createSubjectMap = (
-  subjects: Subject[]
+  subjects: Array<Subject>
 ): Record<string, Subject> => {
   const subjectMap = subjects.reduce<Record<string, Subject>>(
     (acc, subject) => {
@@ -42,7 +43,7 @@ export const createSubjectMap = (
   return subjectMap;
 };
 
-// TODO: when integrating api hydration should be done on the backend - change this to fetch from api
+// TODO: when integrating api, hydration should be done on the backend - change this to fetch from api
 export const hydratePaths = (guides: Array<Guide>, paths: Array<Path>): Array<HydratedPath> => {
   const guideMap = createGuideMap(guides);
 
@@ -71,7 +72,6 @@ export const hydrateGuide = (
 
     tags: guide.tags
       .map((slug) => subjectMap[slug])
-      .filter((subject): subject is Subject => !!subject)
       .map<SubjectReference>((subject) => ({
         slug: subjectMap[subject.slug].slug,
         name: subjectMap[subject.slug].name
@@ -79,10 +79,9 @@ export const hydrateGuide = (
 
     prerequisites: guide.prerequisites
       .map((slug) => guideMap[slug])
-      .filter((guide): guide is Guide => !!guide)
-      .map<GuideReference>((guide) => ({
-        slug: guide.slug,
-        title: guide.title,
+      .map<GuideReference>((prereq) => ({
+        slug: prereq.slug,
+        title: prereq.title,
       })),
   };
 };

--- a/app/src/lib/guideUtils.ts
+++ b/app/src/lib/guideUtils.ts
@@ -1,6 +1,7 @@
 import { unified } from "unified"
 import remarkParse from "remark-parse"
 
+
 // format duration mins -> hrs & mins
 export function formatDuration(minutes: number): string {
   const hours = Math.floor(minutes / 60);
@@ -16,6 +17,7 @@ export function formatDuration(minutes: number): string {
 
   return `${hours} hr${hours > 1 ? "s" : ""} ${mins} min`;
 }
+
 
 // extract headings from markdown content
 export const extractHeadings = (markdown: string) => {

--- a/app/src/routes/guides.$slug.tsx
+++ b/app/src/routes/guides.$slug.tsx
@@ -9,15 +9,20 @@ import {
   Pencil,
 } from "lucide-react"
 
+import type { GuideReference, HydratedGuide } from "@/types/guides"
+
 import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-
-import { extractHeadings, formatDuration } from "@/lib/guideUtils"
 import { CollapsibleSection } from "@/components/CollapsibleSection"
 
+
+import { extractHeadings, formatDuration } from "@/lib/guideUtils"
+import { getGuideBySlug, hydrateGuide } from "@/lib/getData"
+
 import guides from "@/data/guides.json"
-import { getGuideBySlug } from "@/lib/getData"
+import subjects from "@/data/subjects.json"
+import type { SubjectReference } from "@/types/subjects"
 
 export const Route = createFileRoute("/guides/$slug")({
   component: RouteComponent,
@@ -30,20 +35,27 @@ function RouteComponent() {
 
   if (!guide) { throw notFound }
 
+  const hydratedGuide: HydratedGuide = hydrateGuide(guide, guides, subjects);
+
   const headings = useMemo(() => extractHeadings(guide.content), [])
 
   return (
     <div className="mx-auto max-w-[1280px] h-[calc(100vh-70px)] border-x bg-background">
 
       <section className="grid grid-cols-[320px_1fr] border-b">
-
         {/* SIDEBAR */}
         <aside className="h-[calc(100vh-70px)] overflow-y-auto border-r px-6 py-6">
           {/* Prerequisites */}
           <CollapsibleSection title="Prerequisites">
-            <ul className="list-disc pl-4">
-              {guide.prerequisites.map((item: string) => (
-                <li key={item}>{item}</li>
+            <ul className="space-y-2">
+              {hydratedGuide.prerequisites.map((prereq: GuideReference) => (
+                <li
+                  key={prereq.slug}
+                  className="text-sm text-muted-foreground hover:text-foreground cursor-pointer"
+                  style={{
+                    paddingLeft: 6
+                  }}
+                >{prereq.title}</li>
               ))}
             </ul>
           </CollapsibleSection>
@@ -56,7 +68,7 @@ function RouteComponent() {
                   key={idx}
                   className="text-sm text-muted-foreground hover:text-foreground cursor-pointer"
                   style={{
-                    paddingLeft: h.level === 2 ? 0 : h.level === 3 ? 12 : 24,
+                    paddingLeft: h.level === 1 ? 6 : h.level === 2 ? 12 : h.level === 3 ? 24: 28,
                   }}
                 >
                   {h.text}
@@ -79,7 +91,7 @@ function RouteComponent() {
           <div className="mb-6 flex items-center justify-between">
 
             <ul className="flex items-center gap-2 text-xs uppercase tracking-[0.08em] text-muted-foreground">
-              {guides[0].breadcrumbs.map((crumb: string, idx: number) => (
+              {hydratedGuide.breadcrumbs.map((crumb: string, idx: number) => (
                 <li key={crumb} className="flex items-center gap-2 mono-micro">
                   <span>{crumb}</span>
                   {idx < guides[0].breadcrumbs.length - 1 && <span>/</span>}
@@ -120,31 +132,33 @@ function RouteComponent() {
           <Separator className="mb-8" />
 
           {/* Header */}
-          <header className="mb-10">
+          <header className="mb-5">
             <h1 className="text-3xl font-bold tracking-[-0.04em]">
-              {guides[0].title}
+              {hydratedGuide.title}
             </h1>
 
             <div className="mt-3 mono-micro">
-              {guides[0].author} | {guides[0].created_at} | {formatDuration(guide.duration)}
+              {hydratedGuide.author} | {guides[0].created_at} | {formatDuration(guide.duration)}
             </div>
 
             <div className="mt-4 flex gap-2">
-              {guides[0].tags.map((tag: string) => (
+              {hydratedGuide.tags.map((tag: SubjectReference) => (
                 <Badge
-                  key={tag}
+                  key={tag.slug}
                   variant="outline"
                   className="rounded-full border bg-badge text-badge-foreground mono-micro tracking-[0.08em]"
                 >
-                  {tag}
+                  {tag.name}
                 </Badge>
               ))}
             </div>
           </header>
 
+          <Separator className="mb-8" />
+
           <article className="markdown">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {guides[0].content}
+              {hydratedGuide.content}
             </ReactMarkdown>
           </article>
         </main>

--- a/app/src/routes/guides.$slug.tsx
+++ b/app/src/routes/guides.$slug.tsx
@@ -3,11 +3,9 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { useMemo } from "react"
 import {
-  Bookmark,
   ChevronDown,
   ChevronUp,
   Flag,
-  MessageSquare,
   Pencil,
 } from "lucide-react"
 

--- a/app/src/routes/guides.$slug.tsx
+++ b/app/src/routes/guides.$slug.tsx
@@ -1,28 +1,38 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, notFound } from "@tanstack/react-router"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { useMemo } from "react"
 import {
   Bookmark,
-  ExternalLink,
+  ChevronDown,
+  ChevronUp,
   Flag,
   MessageSquare,
+  Pencil,
 } from "lucide-react"
 
 import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 
-import guides from "@/data/guides.json"
-import { extractHeadings } from "@/lib/guideUtils"
+import { extractHeadings, formatDuration } from "@/lib/guideUtils"
 import { CollapsibleSection } from "@/components/CollapsibleSection"
+
+import guides from "@/data/guides.json"
+import { getGuideBySlug } from "@/lib/getData"
 
 export const Route = createFileRoute("/guides/$slug")({
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  const headings = useMemo(() => extractHeadings(guides[0].content), [])
+  const { slug } = Route.useParams()
+
+  const guide = getGuideBySlug(guides, slug);
+
+  if (!guide) { throw notFound }
+
+  const headings = useMemo(() => extractHeadings(guide.content), [])
 
   return (
     <div className="mx-auto max-w-[1280px] h-[calc(100vh-70px)] border-x bg-background">
@@ -31,36 +41,10 @@ function RouteComponent() {
 
         {/* SIDEBAR */}
         <aside className="h-[calc(100vh-70px)] overflow-y-auto border-r px-6 py-6">
-
-          {/* Cards */}
-          <div className="mb-6 grid grid-cols-2 gap-3 text-center">
-
-            <div className="rounded-md border p-3 place-content-center">
-              <p className="data-label">
-                Read time
-              </p>
-              <p className="mt-1 data-value">10 min</p>
-            </div>
-
-            <div className="rounded-md border p-3 place-content-center">
-              <p className="data-label">
-                Level
-              </p>
-              <p className="mt-1 data-value">3</p>
-
-              <Button
-                variant="link"
-                className="mt-1 h-auto p-0 text-xs text-brand-blue"
-              >
-                View Graph <ExternalLink className="ml-1 h-3 w-3" />
-              </Button>
-            </div>
-          </div>
-
           {/* Prerequisites */}
           <CollapsibleSection title="Prerequisites">
             <ul className="list-disc pl-4">
-              {guides[0].prerequisites.map((item: string) => (
+              {guide.prerequisites.map((item: string) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
@@ -107,12 +91,20 @@ function RouteComponent() {
 
             {/* Actions */}
             <div className="flex items-center gap-2">
-              <Button variant="ghost" size="icon">
-                <MessageSquare className="h-4 w-4" />
+              <Button variant="default" size="icon">
+                <Pencil className="h-4 w-4" />
+              </Button>
+
+              <Button variant="outline">
+                Open in Graph
               </Button>
 
               <Button variant="ghost" size="icon">
-                <Bookmark className="h-4 w-4" />
+                <ChevronUp className="h-4 w-4" />
+              </Button>
+
+              <Button variant="ghost" size="icon">
+                <ChevronDown className="h-4 w-4" />
               </Button>
 
               <Button variant="ghost" size="icon">
@@ -136,7 +128,7 @@ function RouteComponent() {
             </h1>
 
             <div className="mt-3 mono-micro">
-              {guides[0].author} • {guides[0].created_at}
+              {guides[0].author} | {guides[0].created_at} | {formatDuration(guide.duration)}
             </div>
 
             <div className="mt-4 flex gap-2">

--- a/app/src/routes/guides.$slug.tsx
+++ b/app/src/routes/guides.$slug.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
 } from "lucide-react"
 
+import type { SubjectReference } from "@/types/subjects"
 import type { GuideReference, HydratedGuide } from "@/types/guides"
 
 import { Separator } from "@/components/ui/separator"
@@ -22,7 +23,6 @@ import { getGuideBySlug, hydrateGuide } from "@/lib/getData"
 
 import guides from "@/data/guides.json"
 import subjects from "@/data/subjects.json"
-import type { SubjectReference } from "@/types/subjects"
 
 export const Route = createFileRoute("/guides/$slug")({
   component: RouteComponent,

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { Search, SlidersHorizontal, X } from "lucide-react"
+import { ChevronRight, Search, SlidersHorizontal, X } from "lucide-react"
 
 import type { HydratedPath } from "@/types/paths"
 
@@ -96,21 +96,36 @@ function RouteComponent() {
         <Separator className="mb-4 bg-border" />
 
         <div className="flex flex-wrap gap-3">
-          {subjects.map((subject) => (
-            <Link
-              to={SubjectRoute.to}
-              params={{ slug: subject.slug }}
-              key={subject.slug}
-            >
-              <Badge
-                variant="outline"
-                className="rounded-full border p-6 mono-micro tracking-[0.08em] transition-colors hover:bg-badge"
+          {[...subjects]
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .slice(0, 24)
+            .map((subject) => (
+              <Link
+                to={SubjectRoute.to}
+                params={{ slug: subject.slug }}
+                key={subject.slug}
               >
-                {subject.name}
-              </Badge>
-            </Link>
-          ))}
+                <Badge
+                  variant="outline"
+                  className="rounded-full border p-4 mono-micro tracking-[0.08em] transition-colors hover:bg-badge"
+                >
+                  {subject.name}
+                </Badge>
+              </Link>
+            ))}
         </div>
+
+        {subjects.length > 24 && (
+          <div className="flex justify-center">
+            <Link
+              to="/subjects"
+              className="p-4 inline-flex justify-center items-center mono-micro uppercase tracking-[0.08em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Show More Subjects
+              <ChevronRight />
+            </Link>
+          </div>
+        )}
       </section>
 
       {/* Featured Section */}

--- a/app/src/routes/paths.$slug.tsx
+++ b/app/src/routes/paths.$slug.tsx
@@ -33,7 +33,7 @@ function PathPage() {
         <Separator className="mb-4 bg-border" />
         
         {/* Grid */}
-        <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
           {hydratedPaths[0].levels.map((level: Level) => (
             <GuideCard key={level.guide.slug} guide={level.guide} level={level.level} />
           ))}

--- a/app/src/routes/paths.index.tsx
+++ b/app/src/routes/paths.index.tsx
@@ -7,8 +7,8 @@ import { PathCard } from "@/components/cards/PathCard"
 
 import { hydratePaths } from "@/lib/getData"
 
-import paths from "@/data/paths.json"
 import guides from "@/data/guides.json"
+import paths from "@/data/paths.json"
 
 
 export const Route = createFileRoute("/paths/")({ component: RouteComponent })

--- a/app/src/routes/paths.index.tsx
+++ b/app/src/routes/paths.index.tsx
@@ -28,7 +28,7 @@ function RouteComponent() {
         <Separator className="mb-4 bg-border" />
 
         {/* Grid */}
-        <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
           {hydratedPaths.map((path: HydratedPath) => (
             <PathCard key={path.slug} path={path} />
           ))}

--- a/app/src/routes/subjects.$slug.tsx
+++ b/app/src/routes/subjects.$slug.tsx
@@ -35,7 +35,7 @@ function SubjectPage() {
         <Separator className="mb-4 bg-border" />
 
         {/* Grid */}
-        <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
           {hydratedPaths.map((path: HydratedPath) => (
             <PathCard key={path.slug} path={path} />
           ))}
@@ -52,7 +52,7 @@ function SubjectPage() {
         <Separator className="mb-4 bg-border" />
 
         {/* Grid */}
-        <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
           {allGuides.map((guide) => (
             <GuideCard key={guide.slug} guide={guide} />
           ))}

--- a/app/src/routes/subjects.index.tsx
+++ b/app/src/routes/subjects.index.tsx
@@ -22,7 +22,7 @@ function RouteComponent() {
         <Separator className="mb-4 bg-border" />
 
         {/* Grid */}
-        <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
           {subjects.map((subject: Subject) => (
             <SubjectCard key={subject.slug} subject={subject} />
           ))}

--- a/app/src/types/guides.ts
+++ b/app/src/types/guides.ts
@@ -1,4 +1,4 @@
-import type { Subject } from "@/types/subjects";
+import type { SubjectReference } from "@/types/subjects";
 
 export type Guide = {
   slug: string;
@@ -13,6 +13,15 @@ export type Guide = {
   content: string;
 };
 
-export type HydratedGuide = Omit<Guide, "tags"> & {
-  tags: Array<Subject>;
+export type GuideReference = {
+  slug: string;
+  title: string;
+};
+
+export type HydratedGuide = Omit<
+  Guide,
+  "tags" | "prerequisites"
+> & {
+  tags: Array<SubjectReference>;
+  prerequisites: Array<GuideReference>;
 };

--- a/app/src/types/subjects.ts
+++ b/app/src/types/subjects.ts
@@ -7,3 +7,7 @@ export type Subject = {
     contributors_total: number;
     languages_total: number;
 }
+export type SubjectReference = {
+    slug: string;
+    name: string;
+}


### PR DESCRIPTION

## Summary
- Removed "level number" card from guide view page
- Moved "read time" card next to author and date
- Removed following guide action buttons (not required for v1):
  - Comment
  - Save
- Added the following guide action buttons:
  - Edit
  - Open in Graph
  - Upvote
  - Downvote
- Add link to browse by subject on homepage

## Type of change
- Feature

## How was this tested?
- `pnpm -r typecheck` passes
- `pnpm -r build` passes
- Manually verified in a browser (for UI / behavior changes)
- Followed the app layout conventions
- No new dependencies, or new dependencies justified in the
description and licenses are AGPL-compatible
- Change does not violate any non-negotiable principle

