### PR TITLE
refactor(api): extract subject routes into service layer

### DIFF
--- a/api/src/routes/subjects.ts
+++ b/api/src/routes/subjects.ts
@@ -3,106 +3,36 @@ import { requireUser } from '../middleware/auth.middleware'
 import type { HonoEnv } from '../types'
 import { createSubjectSchema } from '@bluelearn/schemas'
 import { zValidator } from '@hono/zod-validator'
-import { slugify } from '../lib/slug'
+import {
+  createSubject,
+  getSubjectBySlug,
+  listSubjectGuides,
+  listSubjects,
+} from '../services/subject.service'
 
 export const subjectsRouter = new Hono<HonoEnv>()
   // List all subjects
   .get('/', async (c) => {
-    const supabase =  c.get('supabase')
-    const {data: subjectList, error} = await supabase
-      .from('subjects')
-      .select('id, slug, name')
-
-    if (error) {
-      return c.json({error: error.message}, 500);
-    }
-    return c.json({subjects: subjectList}, 200)
+    const subjects = await listSubjects(c.get('supabase'))
+    return c.json({ subjects }, 200)
   })
 
   // Create a subject
   .post('/', requireUser, zValidator('json', createSubjectSchema), async (c) => {
-    const supabase = c.get('supabase')
-    const user = c.get('user')
-
-    const { name } = await c.req.valid('json')
-    const slug = slugify(name)
-    if (!slug) {
-      return c.json({ error: 'Title must contain at least one letter or number' }, 400)
-    }
-
-    // insert row to subjects
-    const {data: insert_data, error: insert_error} = await supabase
-      .from('subjects')
-      .insert({slug: slug, name: name, creator_id: user.id})
-      .select('id, slug, name')
-      .single()
-    if (insert_error) {
-      if (insert_error.code === '23505') {
-        return c.json({error: 'Error: This subject name is a duplicate of an existing subject.'}, 409)
-      }
-      return c.json({error: insert_error.message}, 500)
-    }
-    
-    return c.json({subject: insert_data}, 201)
+    const { name } = c.req.valid('json')
+    const subject = await createSubject(c.get('supabase'), c.get('user').id, name)
+    return c.json({ subject }, 201)
   })
 
-  // Subject metadata only (the tagged list is a separate call)
+  // Subject metadata only
   .get('/:slug', async (c) => {
-    const supabase =  c.get('supabase')
-    const slug = c.req.param('slug')
-    const {data, error} = await supabase
-      .from('subjects')
-      .select('*')
-      .eq('slug', slug)
-      .maybeSingle()
-    if (error) {
-      return c.json({error: error.message}, 500)
-    }
-    if (!data) {
-      return c.json({error: 'Subject not found.'}, 404)
-    }
-    return c.json({subject: data}, 200)
+    const subject = await getSubjectBySlug(c.get('supabase'), c.req.param('slug'))
+    return c.json({ subject }, 200)
   })
 
-  // Alphabetical list of topics carrying this subject tag
+  // Alphabetical list of guides carrying this subject tag
   .get('/:slug/guides', async (c) => {
-    const supabase = c.get('supabase')
-    const slug = c.req.param('slug')
-    
-    // select id of desired subject matchine inputted slug
-    const {data: subject, error} = await supabase
-      .from('subjects')
-      .select('id')
-      .eq('slug', slug)
-      .maybeSingle()
-    if (error) {
-      return c.json({error: error.message}, 500) 
-    }
-    if (!subject) {
-      return c.json({ error: 'Subject not found' }, 404)
-    }
-
-    // get ID of guide base matching subject ID
-    const {data: guide_base_id, error: guide_error} = await supabase
-      .from('guide_subjects')
-      .select('guide_base_id')
-      .eq('subject_id', subject.id)
-    if (guide_error) {
-      return c.json({error: guide_error.message}, 500)
-    }
-
-    const ids = guide_base_id.map(r => r.guide_base_id)
-    if (ids.length === 0) return c.json([], 200)
-
-    // get guide base metadate from it's ID
-    const {data: guide_base_data, error: guide_base_error} = await supabase
-      .from('guide_bases')
-      .select('slug, title, knowledge_type')
-      .in('id', ids)
-      .order('title')
-    if (guide_base_error) {
-      return c.json({error: guide_base_error.message}, 500)
-    }
-
-    return c.json({guide_bases: guide_base_data}, 200)
+    const guides = await listSubjectGuides(c.get('supabase'), c.req.param('slug'))
+    if (guides.length === 0) return c.json([], 200)
+    return c.json({ guide_bases: guides }, 200)
   })

--- a/api/src/routes/subjects.ts
+++ b/api/src/routes/subjects.ts
@@ -33,6 +33,5 @@ export const subjectsRouter = new Hono<HonoEnv>()
   // Alphabetical list of guides carrying this subject tag
   .get('/:slug/guides', async (c) => {
     const guides = await listSubjectGuides(c.get('supabase'), c.req.param('slug'))
-    if (guides.length === 0) return c.json([], 200)
     return c.json({ guide_bases: guides }, 200)
   })

--- a/api/src/services/subject.service.ts
+++ b/api/src/services/subject.service.ts
@@ -1,0 +1,79 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../database.types'
+import { ServiceError } from '../lib/service-error'
+import { slugify } from '../lib/slug'
+
+type DB = SupabaseClient<Database>
+
+export async function listSubjects(supabase: DB) {
+  const { data, error } = await supabase
+    .from('subjects')
+    .select('id, slug, name')
+
+  if (error) throw new ServiceError(error.message, 500)
+  return data ?? []
+}
+
+export async function createSubject(supabase: DB, userId: string, name: string) {
+  const slug = slugify(name)
+  if (!slug) throw new ServiceError('Title must contain at least one letter or number', 400)
+
+  const { data, error } = await supabase
+    .from('subjects')
+    .insert({ slug, name, creator_id: userId })
+    .select('id, slug, name')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') {
+      throw new ServiceError('Error: This subject name is a duplicate of an existing subject.', 409)
+    }
+    throw new ServiceError(error.message, 500)
+  }
+
+  return data
+}
+
+export async function getSubjectBySlug(supabase: DB, rawSlug: string) {
+  const { data, error } = await supabase
+    .from('subjects')
+    .select('*')
+    .eq('slug', rawSlug)
+    .maybeSingle()
+
+  if (error) throw new ServiceError(error.message, 500)
+  if (!data) throw new ServiceError('Subject not found.', 404)
+
+  return data
+}
+
+export async function listSubjectGuides(supabase: DB, rawSlug: string) {
+  const { data: subject, error } = await supabase
+    .from('subjects')
+    .select('id')
+    .eq('slug', rawSlug)
+    .maybeSingle()
+
+  if (error) throw new ServiceError(error.message, 500)
+  if (!subject) throw new ServiceError('Subject not found', 404)
+
+  const { data: guideSubjects, error: guideError } = await supabase
+    .from('guide_subjects')
+    .select('guide_base_id')
+    .eq('subject_id', subject.id)
+
+  if (guideError) throw new ServiceError(guideError.message, 500)
+
+  const ids = guideSubjects.map((r) => r.guide_base_id)
+  if (ids.length === 0) return []
+
+  const { data: guideBases, error: baseError } = await supabase
+    .from('guide_bases')
+    .select('slug, title, knowledge_type')
+    .in('id', ids)
+    .order('title')
+
+  if (baseError) throw new ServiceError(baseError.message, 500)
+
+  return guideBases ?? []
+}


### PR DESCRIPTION
Move all business logic, database queries, and validation out of route handlers into dedicated service functions in subject.service.ts. Routes are now thin — they parse input, call a service function, and return JSON. Follows the same architecture used by guides and identity.



## Summary



## Related issues



## Type of change

- Bug fix
- Feature
- Refactor (no behavior change)
- Documentation
- Build / tooling / CI
- Other:

## How was this tested?



## Checklist

- `pnpm -r typecheck` passes
- `pnpm -r build` passes
- Manually verified in a browser (for UI / behavior changes)
- Followed the app layout conventions
- No new dependencies, or new dependencies justified in the
description and licenses are AGPL-compatible
- Change does not violate any non-negotiable principle

