### PR TITLE
fix: respect defaultOpen prop in CollapsibleSection

### DIFF
--- a/app/src/components/CollapsibleSection.tsx
+++ b/app/src/components/CollapsibleSection.tsx
@@ -16,7 +16,7 @@ export const CollapsibleSection = ({
   defaultOpen?: boolean,
   children: React.ReactNode
 }) => {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(defaultOpen ?? false)
 
   return (
     <Collapsible defaultOpen={defaultOpen} open={open} onOpenChange={setOpen} className="border-b py-4 group">


### PR DESCRIPTION
## Summary

The CollapsibleSection component ignored the `defaultOpen` prop, state was always initialized to `false`. Fixed by using `defaultOpen ?? false` as the initial state value.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required