### PR TITLE
feat(app): improve guide code block styling and add copy button

### DIFF
--- a/app/src/components/CodeBlock.tsx
+++ b/app/src/components/CodeBlock.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type CodeBlockProps = {
+  code: string;
+  language?: string;
+};
+
+export function CodeBlock({ code, language }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+
+      setCopied(true);
+
+      window.setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error("Failed to copy code", error);
+    }
+  }
+
+  return (
+    <div className="relative my-6 overflow-hidden rounded-lg border bg-muted">
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <span className="text-xs text-muted-foreground uppercase">
+          {language ?? "text"}
+        </span>
+
+        <Button variant="ghost" size="sm" onClick={handleCopy} type="button">
+          {copied ? (
+            <>
+              <Check />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+
+      <pre className="codeblock-pre overflow-x-auto p-4">
+        <code className="font-mono text-sm">{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/app/src/components/CodeBlock.tsx
+++ b/app/src/components/CodeBlock.tsx
@@ -47,7 +47,7 @@ export function CodeBlock({ code, language }: CodeBlockProps) {
         </Button>
       </div>
 
-      <pre className="codeblock-pre overflow-x-auto p-4">
+      <pre className="m-0 overflow-x-auto border-0 bg-transparent p-4">
         <code className="font-mono text-sm">{code}</code>
       </pre>
     </div>

--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -5,8 +5,10 @@ import remarkMath from "remark-math";
 
 import type { SubjectReference } from "@/types/subjects";
 import type { GuideType, HydratedGuide } from "@/types/guides";
+import type { ReactElement } from "react";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components//ui/badge";
+import { CodeBlock } from "@/components/CodeBlock";
 
 import { formatDuration } from "@/lib/guideUtils";
 
@@ -57,6 +59,31 @@ export const GuideReader = ({ guide, guideType }: PropTypes) => {
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkMath]}
           rehypePlugins={[rehypeKatex]}
+          components={{
+            pre({ children }) {
+              const child = children as ReactElement<{
+                className?: string;
+                children?: React.ReactNode;
+              }>;
+
+              const code = String(child.props.children).replace(/\n$/, "");
+              const language = child.props.className?.replace("language-", "");
+
+              return <CodeBlock code={code} language={language} />;
+            },
+
+            code({ children, className }) {
+              if (className) {
+                return <code className={className}>{children}</code>;
+              }
+
+              return (
+                <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                  {children}
+                </code>
+              );
+            },
+          }}
         >
           {guide.content}
         </ReactMarkdown>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -294,7 +294,7 @@
     @apply list-decimal space-y-1 pl-5;
   }
 
-  .markdown pre {
+  .markdown pre:not(.codeblock-pre) {
     @apply my-4 max-w-full overflow-x-auto rounded-lg border border-border bg-muted p-4 font-mono text-sm;
   }
 


### PR DESCRIPTION
## Summary

Improve the styling of fenced code blocks in guide pages and add a copy button for easier reuse of code snippets.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required

Closes #66 