### PR TITLE
fix(app): mobile sizing for card footers and objectivecard

### DIFF
--- a/app/src/components/FeaturedRow.tsx
+++ b/app/src/components/FeaturedRow.tsx
@@ -35,13 +35,15 @@ export const FeaturedRow = ({ objectives, type }: PropTypes) => {
             ],
           };
           return (
-            <div key={objective.slug} className="w-[550px] shrink-0">
+            <div
+              key={objective.slug}
+              className="w-[calc(100vw_-_8rem)] shrink-0 sm:w-[550px]"
+            >
               <ObjectiveCard
                 key={o.slug}
                 objective={o}
                 to={ObjectiveRoute.to}
               />
-              ;
             </div>
           );
         })}

--- a/app/src/components/cards/Footer.tsx
+++ b/app/src/components/cards/Footer.tsx
@@ -12,7 +12,7 @@ type PropTypes = {
 
 export const Footer = ({ data }: PropTypes) => {
   return (
-    <CardFooter className="grid grid-cols-2 border-t p-0 lg:grid-cols-4">
+    <CardFooter className="grid grid-cols-2 border-t p-0 sm:grid-cols-4 [&>*:last-child]:border-r-0">
       {data.stats?.map((g: { label: string; data: number }) => {
         return <FooterStats key={g.label} label={g.label} data={g.data} />;
       })}

--- a/app/src/components/cards/FooterStats.tsx
+++ b/app/src/components/cards/FooterStats.tsx
@@ -6,7 +6,7 @@ type StatProps = {
 export const FooterStats = ({ label, data }: StatProps) => {
   if (data) {
     return (
-      <div className="border-r px-4">
+      <div className="border-r px-4 pb-4 sm:pb-0">
         <p className="font-mono text-[10px] tracking-[0.08em] text-muted-foreground uppercase">
           {label}
         </p>

--- a/app/src/components/cards/ObjectiveCard.tsx
+++ b/app/src/components/cards/ObjectiveCard.tsx
@@ -57,14 +57,14 @@ export const ObjectiveCard = ({ objective, to }: PropTypes) => {
 
         {/* Graph Preview */}
         <CardContent className="space-y-2 border-t p-4">
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             {previewLevels.map((level, index) => (
               <div
                 key={index}
-                className="flex min-w-0 flex-1 items-center gap-2"
+                className="flex flex-col items-center gap-2 sm:min-w-0 sm:flex-1 sm:flex-row"
               >
-                <div className="flex flex-col items-center justify-center">
-                  <p className="flex h-8 w-8 items-center justify-center rounded-full bg-badge px-2 text-xl">
+                <div className="flex w-40 flex-col items-center justify-center sm:w-auto sm:min-w-0">
+                  <p className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-badge px-2 text-xl">
                     {level.level}
                   </p>
 
@@ -75,7 +75,7 @@ export const ObjectiveCard = ({ objective, to }: PropTypes) => {
 
                 {(index < previewLevels.length - 1 ||
                   objective.levels.length >= 3) && (
-                  <ArrowRight className="h-5 w-5 shrink-0" />
+                  <ArrowRight className="h-5 w-5 shrink-0 rotate-90 sm:rotate-0" />
                 )}
                 {index >= previewLevels.length - 1 && (
                   <div className="text-center">


### PR DESCRIPTION
## Summary

Fixes mobile layout issues in objective cards and card footers where content was overflowing or misaligned on small screens.

- `FeaturedRow`: cards now scale to viewport width on mobile (`calc(100vw - 8rem)`) instead of a fixed 550px, and removes a stray literal `;` left in the JSX.
- `Footer`/`FooterStats`: footer stat grid collapses to 2 columns on mobile (was forcing 4 via `lg:`), with bottom padding and border adjustments so the last row/column don't look cut off.
- `ObjectiveCard`: level preview switches from a horizontal row to a stacked column on mobile, with the connecting arrow rotated 90° to match the vertical flow, reverting to the original horizontal layout at `sm:` and up.

Fixes #46 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
