### PR TITLE
feat(api): add rate-limiting middleware

### DIFF
--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -16,8 +16,8 @@ TYPESENSE_API_KEY=
 # Frontend origin for CORS (Vite dev server)
 APP_URL=http://localhost:3000
 
-# Rate limiting: RATE_LIMIT_KV is bound in wrangler.jsonc, not here,
-# since it's a KV namespace, not a secret. Create it locally with:
-#   pnpm --filter api exec wrangler kv namespace create RATE_LIMIT_KV
-# Then paste the printed id into wrangler.jsonc. Without it, wrangler dev
-# falls back to in-memory counters (reset on every restart).
+# Rate limiting: RATE_LIMITER is a Durable Object binding declared in
+# wrangler.jsonc (not a secret, so not here). `wrangler dev` creates the
+# DO locally and stores its state in .wrangler/state/v3/do/. No setup
+# needed. Tests run without the binding and fall back to in-memory
+# counters automatically.

--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -15,3 +15,9 @@ TYPESENSE_API_KEY=
 
 # Frontend origin for CORS (Vite dev server)
 APP_URL=http://localhost:3000
+
+# Rate limiting: RATE_LIMIT_KV is bound in wrangler.jsonc, not here,
+# since it's a KV namespace, not a secret. Create it locally with:
+#   pnpm --filter api exec wrangler kv namespace create RATE_LIMIT_KV
+# Then paste the printed id into wrangler.jsonc. Without it, wrangler dev
+# falls back to in-memory counters (reset on every restart).

--- a/api/openapi/components/responses/_shared.yaml
+++ b/api/openapi/components/responses/_shared.yaml
@@ -34,3 +34,17 @@ NotFound:
         $ref: "../schemas/common/Error.yaml"
       example:
         error: Not found
+RateLimited:
+  description: Too many requests
+  headers:
+    Retry-After:
+      description: Seconds until the next request is allowed
+      schema:
+        type: integer
+        minimum: 1
+  content:
+    application/json:
+      schema:
+        $ref: "../schemas/common/Error.yaml"
+      example:
+        error: Rate limit exceeded

--- a/api/openapi/paths/guides.yaml
+++ b/api/openapi/paths/guides.yaml
@@ -51,6 +51,8 @@
         $ref: "../components/responses/_shared.yaml#/BadRequest"
       "401":
         $ref: "../components/responses/_shared.yaml#/Unauthorized"
+      "429":
+        $ref: "../components/responses/_shared.yaml#/RateLimited"
 
 /guides/{slug}:
   parameters:

--- a/api/src/durable-objects/rate-limiter.do.ts
+++ b/api/src/durable-objects/rate-limiter.do.ts
@@ -1,0 +1,47 @@
+type Counter = { count: number; resetAt: number };
+
+type HitRequest = {
+  action: "hit";
+  windowSeconds: number;
+};
+
+// One instance per user (via idFromName). The Workers runtime serializes
+// fetch handlers within an instance, so read-modify-write on state.storage
+// is atomic -- no race between concurrent requests.
+export class RateLimiterDurableObject implements DurableObject {
+  constructor(private state: DurableObjectState) {}
+
+  async fetch(request: Request): Promise<Response> {
+    let body: HitRequest;
+    try {
+      body = (await request.json()) as HitRequest;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (body.action !== "hit") {
+      return Response.json({ error: "Unknown action" }, { status: 400 });
+    }
+
+    // The DO is scoped to one user, so the storage key only needs the
+    // window length -- no user id prefix.
+    const storageKey = `counter:${body.windowSeconds}`;
+    const now = Math.floor(Date.now() / 1000);
+
+    const existing = await this.state.storage.get<Counter>(storageKey);
+    let counter: Counter;
+
+    if (!existing || existing.resetAt <= now) {
+      counter = { count: 1, resetAt: now + body.windowSeconds };
+    } else {
+      counter = {
+        count: existing.count + 1,
+        resetAt: existing.resetAt,
+      };
+    }
+
+    await this.state.storage.put(storageKey, counter);
+
+    return Response.json({ count: counter.count, resetAt: counter.resetAt });
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -62,3 +62,5 @@ async function scheduled(_event: ScheduledController, env: Bindings) {
 // fetch and scheduled runs assembly. Tests import it to call app.request().
 export default Object.assign(app, { scheduled });
 export type AppType = typeof app;
+
+export { RateLimiterDurableObject } from "./durable-objects/rate-limiter.do";

--- a/api/src/middleware/rate-limit.middleware.ts
+++ b/api/src/middleware/rate-limit.middleware.ts
@@ -1,4 +1,4 @@
-import type { Context, MiddlewareHandler } from "hono";
+import type { MiddlewareHandler } from "hono";
 import type { HonoEnv } from "../types";
 
 type RateLimitOptions = {
@@ -10,130 +10,75 @@ type RateLimitOptions = {
 type Counter = { count: number; resetAt: number };
 
 interface RateLimiterStore {
-  hit(key: string, windowSeconds: number): Promise<Counter>;
+  hit(windowSeconds: number): Promise<Counter>;
 }
 
-// In-memory store used when no KV namespace is bound (tests, fresh
-// `wrangler dev`). Counters are process-scoped and reset on restart —
-// fine for local dev and the test suite. Each middleware instance gets
-// its own store so counters never leak between independent routes.
+// In-memory store used when no Durable Object binding is present (tests,
+// fresh `wrangler dev` before the DO migration runs). Counters are
+// process-scoped and reset on restart -- fine for local dev and test
+// suites. A singleton keeps middleware instances sharing the same
+// counters during test runs.
 function createInMemoryStore(): RateLimiterStore {
-  const counters = new Map<string, Counter>();
+  const counters = new Map<number, Counter>();
   return {
-    async hit(key, windowSeconds) {
+    async hit(windowSeconds) {
       const now = Math.floor(Date.now() / 1000);
-      const existing = counters.get(key);
+      const existing = counters.get(windowSeconds);
+      let counter: Counter;
       if (!existing || existing.resetAt <= now) {
-        const fresh: Counter = {
-          count: 1,
-          resetAt: now + windowSeconds,
+        counter = { count: 1, resetAt: now + windowSeconds };
+      } else {
+        counter = {
+          count: existing.count + 1,
+          resetAt: existing.resetAt,
         };
-        counters.set(key, fresh);
-        return fresh;
       }
-      existing.count += 1;
-      return existing;
+      counters.set(windowSeconds, counter);
+      return counter;
     },
   };
 }
 
-// Production store backed by Cloudflare Workers KV. Each (key, window)
-// maps to one KV entry storing `{ count, resetAt }` as JSON. The window
-// is bucketed to a fixed start so all requests in the same window share
-// the same KV key, avoiding race conditions on rollover.
-function createKvStore(kv: KVNamespace): RateLimiterStore {
-  return {
-    async hit(key, windowSeconds) {
-      const now = Math.floor(Date.now() / 1000);
-      const windowStart = Math.floor(now / windowSeconds) * windowSeconds;
-      const resetAt = windowStart + windowSeconds;
-      const kvKey = `${key}:${windowStart}`;
+const inMemoryStore = createInMemoryStore();
 
-      const raw = await kv.get(kvKey);
-      const current: Counter = raw
-        ? (JSON.parse(raw) as Counter)
-        : { count: 0, resetAt };
-
-      current.count += 1;
-
-      // TTL with a 60s buffer for clock skew between Worker and KV.
-      await kv.put(kvKey, JSON.stringify(current), {
-        expirationTtl: windowSeconds + 60,
-      });
-
-      return current;
-    },
-  };
-}
-
-// Decode the JWT payload without verifying — `requireUser` runs later
-// and does the real verification. We only need the `sub` claim for
-// keying here. Uses only Web-standard APIs so it works in Workers
-// without nodejs_compat.
-function decodeJwtSubject(token: string): string | null {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-  try {
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const json = atob(base64);
-    const bytes = new Uint8Array(json.length);
-    for (let i = 0; i < json.length; i++) bytes[i] = json.charCodeAt(i);
-    const payload = JSON.parse(new TextDecoder().decode(bytes)) as {
-      sub?: string;
-    };
-    return payload.sub ?? null;
-  } catch {
-    return null;
+async function hitDurableObject(
+  namespace: DurableObjectNamespace,
+  key: string,
+  windowSeconds: number
+): Promise<Counter> {
+  const id = namespace.idFromName(key);
+  const stub = namespace.get(id);
+  const res = await stub.fetch("https://do/internal/hit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "hit", windowSeconds }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `RateLimiterDurableObject returned ${res.status}: ${await res.text()}`
+    );
   }
+  return (await res.json()) as Counter;
 }
 
-// Extract the client IP from Cloudflare's header first, then standard
-// forwarded headers. Falls back to "unknown" for direct app.request()
-// calls in tests.
-function getClientIp(c: Context): string {
-  return (
-    c.req.header("CF-Connecting-IP") ??
-    c.req.header("X-Real-IP") ??
-    c.req.header("X-Forwarded-For")?.split(",")[0]?.trim() ??
-    "unknown"
-  );
-}
-
-// Determine the rate-limit key for this request. Prefers the
-// authenticated user (set by `requireUser`), then the JWT `sub` claim
-// (when the limiter runs before `requireUser`), then the client IP.
-function getIdentity(c: Context<HonoEnv>): string {
-  const user = c.get("user");
-  if (user) return `user:${user.id}`;
-
-  const authHeader = c.req.header("Authorization");
-  if (authHeader?.startsWith("Bearer ")) {
-    const sub = decodeJwtSubject(authHeader.slice(7));
-    if (sub) return `user:${sub}`;
-  }
-
-  return `ip:${getClientIp(c)}`;
-}
-
-// Per-route rate-limit middleware. Mount it after `requireUser` on
-// routes that need per-user limits, or before it for per-IP limits.
-// Returns 429 with a Retry-After header once the limit is exceeded.
+// Per-route rate-limit middleware. Must be mounted AFTER requireUser so
+// that c.get("user") is populated -- we key exclusively on the
+// authenticated user id. Returns 429 with a Retry-After header once the
+// limit is exceeded.
 export function rateLimitMiddleware(
   options: RateLimitOptions
 ): MiddlewareHandler<HonoEnv> {
-  // Fallback store is created once per middleware instance so each
-  // mounted route gets its own counters — no leakage between tests.
-  const fallbackStore = createInMemoryStore();
-
   return async (c, next) => {
-    const store = c.env.RATE_LIMIT_KV
-      ? createKvStore(c.env.RATE_LIMIT_KV)
-      : fallbackStore;
+    const user = c.get("user");
+    // Defensive -- requireUser should always run first.
+    if (!user) return c.json({ error: "Unauthorized" }, 401);
 
-    const identity = getIdentity(c);
-    const key = `rl:${options.windowSeconds}:${identity}`;
+    const key = `user:${user.id}`;
 
-    const { count, resetAt } = await store.hit(key, options.windowSeconds);
+    const { count, resetAt } = c.env.RATE_LIMITER
+      ? await hitDurableObject(c.env.RATE_LIMITER, key, options.windowSeconds)
+      : await inMemoryStore.hit(options.windowSeconds);
+
     const remaining = Math.max(0, options.max - count);
     const now = Math.floor(Date.now() / 1000);
     const retryAfter = Math.max(1, resetAt - now);

--- a/api/src/middleware/rate-limit.middleware.ts
+++ b/api/src/middleware/rate-limit.middleware.ts
@@ -1,0 +1,152 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { HonoEnv } from "../types";
+
+type RateLimitOptions = {
+  windowSeconds: number;
+  max: number;
+  message?: string;
+};
+
+type Counter = { count: number; resetAt: number };
+
+interface RateLimiterStore {
+  hit(key: string, windowSeconds: number): Promise<Counter>;
+}
+
+// In-memory store used when no KV namespace is bound (tests, fresh
+// `wrangler dev`). Counters are process-scoped and reset on restart —
+// fine for local dev and the test suite. Each middleware instance gets
+// its own store so counters never leak between independent routes.
+function createInMemoryStore(): RateLimiterStore {
+  const counters = new Map<string, Counter>();
+  return {
+    async hit(key, windowSeconds) {
+      const now = Math.floor(Date.now() / 1000);
+      const existing = counters.get(key);
+      if (!existing || existing.resetAt <= now) {
+        const fresh: Counter = {
+          count: 1,
+          resetAt: now + windowSeconds,
+        };
+        counters.set(key, fresh);
+        return fresh;
+      }
+      existing.count += 1;
+      return existing;
+    },
+  };
+}
+
+// Production store backed by Cloudflare Workers KV. Each (key, window)
+// maps to one KV entry storing `{ count, resetAt }` as JSON. The window
+// is bucketed to a fixed start so all requests in the same window share
+// the same KV key, avoiding race conditions on rollover.
+function createKvStore(kv: KVNamespace): RateLimiterStore {
+  return {
+    async hit(key, windowSeconds) {
+      const now = Math.floor(Date.now() / 1000);
+      const windowStart = Math.floor(now / windowSeconds) * windowSeconds;
+      const resetAt = windowStart + windowSeconds;
+      const kvKey = `${key}:${windowStart}`;
+
+      const raw = await kv.get(kvKey);
+      const current: Counter = raw
+        ? (JSON.parse(raw) as Counter)
+        : { count: 0, resetAt };
+
+      current.count += 1;
+
+      // TTL with a 60s buffer for clock skew between Worker and KV.
+      await kv.put(kvKey, JSON.stringify(current), {
+        expirationTtl: windowSeconds + 60,
+      });
+
+      return current;
+    },
+  };
+}
+
+// Decode the JWT payload without verifying — `requireUser` runs later
+// and does the real verification. We only need the `sub` claim for
+// keying here. Uses only Web-standard APIs so it works in Workers
+// without nodejs_compat.
+function decodeJwtSubject(token: string): string | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(base64);
+    const bytes = new Uint8Array(json.length);
+    for (let i = 0; i < json.length; i++) bytes[i] = json.charCodeAt(i);
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as {
+      sub?: string;
+    };
+    return payload.sub ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Extract the client IP from Cloudflare's header first, then standard
+// forwarded headers. Falls back to "unknown" for direct app.request()
+// calls in tests.
+function getClientIp(c: Context): string {
+  return (
+    c.req.header("CF-Connecting-IP") ??
+    c.req.header("X-Real-IP") ??
+    c.req.header("X-Forwarded-For")?.split(",")[0]?.trim() ??
+    "unknown"
+  );
+}
+
+// Determine the rate-limit key for this request. Prefers the
+// authenticated user (set by `requireUser`), then the JWT `sub` claim
+// (when the limiter runs before `requireUser`), then the client IP.
+function getIdentity(c: Context<HonoEnv>): string {
+  const user = c.get("user");
+  if (user) return `user:${user.id}`;
+
+  const authHeader = c.req.header("Authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    const sub = decodeJwtSubject(authHeader.slice(7));
+    if (sub) return `user:${sub}`;
+  }
+
+  return `ip:${getClientIp(c)}`;
+}
+
+// Per-route rate-limit middleware. Mount it after `requireUser` on
+// routes that need per-user limits, or before it for per-IP limits.
+// Returns 429 with a Retry-After header once the limit is exceeded.
+export function rateLimitMiddleware(
+  options: RateLimitOptions
+): MiddlewareHandler<HonoEnv> {
+  // Fallback store is created once per middleware instance so each
+  // mounted route gets its own counters — no leakage between tests.
+  const fallbackStore = createInMemoryStore();
+
+  return async (c, next) => {
+    const store = c.env.RATE_LIMIT_KV
+      ? createKvStore(c.env.RATE_LIMIT_KV)
+      : fallbackStore;
+
+    const identity = getIdentity(c);
+    const key = `rl:${options.windowSeconds}:${identity}`;
+
+    const { count, resetAt } = await store.hit(key, options.windowSeconds);
+    const remaining = Math.max(0, options.max - count);
+    const now = Math.floor(Date.now() / 1000);
+    const retryAfter = Math.max(1, resetAt - now);
+
+    c.header("RateLimit-Limit", String(options.max));
+    c.header("RateLimit-Remaining", String(remaining));
+    c.header("RateLimit-Reset", String(retryAfter));
+
+    if (count > options.max) {
+      c.header("Retry-After", String(retryAfter));
+      return c.json({ error: options.message ?? "Rate limit exceeded" }, 429);
+    }
+
+    await next();
+  };
+}

--- a/api/src/middleware/rate-limit.middleware.ts
+++ b/api/src/middleware/rate-limit.middleware.ts
@@ -10,20 +10,23 @@ type RateLimitOptions = {
 type Counter = { count: number; resetAt: number };
 
 interface RateLimiterStore {
-  hit(windowSeconds: number): Promise<Counter>;
+  hit(key: string, windowSeconds: number): Promise<Counter>;
 }
 
 // In-memory store used when no Durable Object binding is present (tests,
 // fresh `wrangler dev` before the DO migration runs). Counters are
 // process-scoped and reset on restart -- fine for local dev and test
 // suites. A singleton keeps middleware instances sharing the same
-// counters during test runs.
+// counters during test runs. Keyed on user+window so users never share a
+// counter -- mirrors the per-user isolation the DO path gets from
+// idFromName(key).
 function createInMemoryStore(): RateLimiterStore {
-  const counters = new Map<number, Counter>();
+  const counters = new Map<string, Counter>();
   return {
-    async hit(windowSeconds) {
+    async hit(key, windowSeconds) {
+      const storageKey = `${key}:${windowSeconds}`;
       const now = Math.floor(Date.now() / 1000);
-      const existing = counters.get(windowSeconds);
+      const existing = counters.get(storageKey);
       let counter: Counter;
       if (!existing || existing.resetAt <= now) {
         counter = { count: 1, resetAt: now + windowSeconds };
@@ -33,7 +36,7 @@ function createInMemoryStore(): RateLimiterStore {
           resetAt: existing.resetAt,
         };
       }
-      counters.set(windowSeconds, counter);
+      counters.set(storageKey, counter);
       return counter;
     },
   };
@@ -77,7 +80,7 @@ export function rateLimitMiddleware(
 
     const { count, resetAt } = c.env.RATE_LIMITER
       ? await hitDurableObject(c.env.RATE_LIMITER, key, options.windowSeconds)
-      : await inMemoryStore.hit(options.windowSeconds);
+      : await inMemoryStore.hit(key, options.windowSeconds);
 
     const remaining = Math.max(0, options.max - count);
     const now = Math.floor(Date.now() / 1000);

--- a/api/src/routes/guides.ts
+++ b/api/src/routes/guides.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
 import type { HonoEnv } from "../types";
 import { zValidator } from "@hono/zod-validator";
 import {
@@ -53,14 +54,21 @@ export const guidesRouter = new Hono<HonoEnv>()
     return c.json({ guides });
   })
 
-  // 201 with { revision_id } for the editor route.
-  .post("/", requireUser, zValidator("json", createGuideBody), async (c) => {
-    const { revision_id } = await createGuide(
-      c.get("supabase"),
-      c.req.valid("json")
-    );
-    return c.json({ revision_id }, 201);
-  })
+  // 201 with { revision_id } for the editor route. Rate-limited to 15
+  // guide creations per 24h per user to prevent spam.
+  .post(
+    "/",
+    requireUser,
+    rateLimitMiddleware({ windowSeconds: 86_400, max: 15 }),
+    zValidator("json", createGuideBody),
+    async (c) => {
+      const { revision_id } = await createGuide(
+        c.get("supabase"),
+        c.req.valid("json")
+      );
+      return c.json({ revision_id }, 201);
+    }
+  )
 
   // Returns the guide content and its subject tags.
   .get("/:slug", async (c) => {

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -3,10 +3,10 @@ export type Bindings = {
   SUPABASE_PUBLISHABLE_KEY: string;
   SUPABASE_SECRET_KEY: string;
   APP_URL: string;
-  // Optional. Bound in wrangler.jsonc via kv_namespaces. When absent
-  // (tests, fresh `wrangler dev`), rate-limit middleware falls back to
-  // an in-memory store.
-  RATE_LIMIT_KV?: KVNamespace;
+  // Optional. Bound in wrangler.jsonc via durable_objects.bindings. When
+  // absent (tests, fresh `wrangler dev` before the migration runs),
+  // rate-limit middleware falls back to an in-memory store.
+  RATE_LIMITER?: DurableObjectNamespace;
 };
 
 export type HonoEnv = { Bindings: Bindings };

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -3,6 +3,10 @@ export type Bindings = {
   SUPABASE_PUBLISHABLE_KEY: string;
   SUPABASE_SECRET_KEY: string;
   APP_URL: string;
+  // Optional. Bound in wrangler.jsonc via kv_namespaces. When absent
+  // (tests, fresh `wrangler dev`), rate-limit middleware falls back to
+  // an in-memory store.
+  RATE_LIMIT_KV?: KVNamespace;
 };
 
 export type HonoEnv = { Bindings: Bindings };

--- a/api/tests/rate-limit.test.ts
+++ b/api/tests/rate-limit.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import app from "../src/index";
+import { env, jsonAuth, makeUser } from "./helpers";
+import { expectToMatchSpec } from "./openapi";
+
+function guideBody() {
+  return {
+    tags: ["algebra"],
+    knowledge_type: "theory" as const,
+    title: "Rate Limit Test Guide",
+    slug: `rl-test-${crypto.randomUUID().slice(0, 8)}`,
+    body: "Body content.",
+  };
+}
+
+describe("POST /guides rate limit", () => {
+  it("allows up to 15 guide creations per user per day", async () => {
+    const { token } = await makeUser();
+
+    for (let i = 0; i < 15; i++) {
+      const res = await app.request(
+        "/guides",
+        jsonAuth(token, "POST", guideBody()),
+        env
+      );
+      expect(res.status).toBe(201);
+    }
+  });
+
+  it("returns 429 on the 16th guide creation within the same day", async () => {
+    const { token } = await makeUser();
+
+    for (let i = 0; i < 15; i++) {
+      await app.request("/guides", jsonAuth(token, "POST", guideBody()), env);
+    }
+
+    const res = await app.request(
+      "/guides",
+      jsonAuth(token, "POST", guideBody()),
+      env
+    );
+
+    expect(res.status).toBe(429);
+    await expectToMatchSpec(res, "POST", "/guides");
+    expect(res.headers.get("Retry-After")).not.toBeNull();
+    const retryAfter = Number(res.headers.get("Retry-After"));
+    expect(retryAfter).toBeGreaterThan(0);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Rate limit exceeded");
+  });
+
+  it("does not share counters between different users", async () => {
+    const first = await makeUser();
+    const second = await makeUser();
+
+    for (let i = 0; i < 15; i++) {
+      await app.request(
+        "/guides",
+        jsonAuth(first.token, "POST", guideBody()),
+        env
+      );
+    }
+
+    const res = await app.request(
+      "/guides",
+      jsonAuth(second.token, "POST", guideBody()),
+      env
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 401 (not 429) for unauthenticated requests", async () => {
+    const res = await app.request("/guides", { method: "POST" }, env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -4,10 +4,18 @@
   "compatibility_date": "2026-05-10",
   "compatibility_flags": ["nodejs_compat"],
   "triggers": { "crons": ["* * * * *"] },
-  "kv_namespaces": [
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "RATE_LIMITER",
+        "class_name": "RateLimiterDurableObject",
+      },
+    ],
+  },
+  "migrations": [
     {
-      "binding": "RATE_LIMIT_KV",
-      "id": "REPLACE_WITH_REAL_KV_NAMESPACE_ID",
+      "tag": "v1",
+      "new_sqlite_classes": ["RateLimiterDurableObject"],
     },
   ],
 }

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -4,4 +4,10 @@
   "compatibility_date": "2026-05-10",
   "compatibility_flags": ["nodejs_compat"],
   "triggers": { "crons": ["* * * * *"] },
+  "kv_namespaces": [
+    {
+      "binding": "RATE_LIMIT_KV",
+      "id": "REPLACE_WITH_REAL_KV_NAMESPACE_ID",
+    },
+  ],
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@
 ┌──────────────────────────────────────────────────────────────────────┐
 │  api/   Hono on Cloudflare Workers                                   │
 │         Routes: /subjects · /walkthroughs · /guides                  │
-│         Middleware: cors, supabaseMiddleware (auth)                  │
+│         Middleware: cors, supabaseMiddleware (auth), rateLimit (POST /guides) │
 │         Validation: @hono/zod-validator                              │
 └───────────────────────────────┬──────────────────────────────────────┘
                                 │  PostgREST / RPC


### PR DESCRIPTION
## Summary

Adds a per-user rate limiter and wires it on `POST /guides` at 15 creations per 24h. Backed by a Cloudflare Durable Object (one instance per user, so counter updates are atomic) with an in-memory fallback for local dev and tests. Also adds the `RATE_LIMITER` binding in `wrangler.jsonc`, a 429 response in the OpenAPI spec, and setup notes in the docs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
