### PR TITLE
feat(app): reset initial contribution data when contribution type changes

### DIFF
--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -1,6 +1,6 @@
 import { defineStepper } from "@stepperize/react";
 import { ChevronRight } from "lucide-react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 
 import type { Dispatch, SetStateAction } from "react";
 

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -1,6 +1,6 @@
 import { defineStepper } from "@stepperize/react";
 import { ChevronRight } from "lucide-react";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 
 import type { Dispatch, SetStateAction } from "react";
 
@@ -25,31 +25,35 @@ type PropTypes = {
   setType: (value: ContributionType) => void;
 };
 
-export default function ContributionFlow({ type, setType }: PropTypes) {
-  const [guideContData, setGuideContData] = useState<GuideContribution>({
-    type: "",
-    title: "",
-    summary: "",
-    subjects: [],
-    newSubjects: [],
-    prereqs: [],
-    todoPrereqs: [],
-  });
+const createGuideContData = (): GuideContribution => ({
+  type: "",
+  title: "",
+  summary: "",
+  subjects: [],
+  newSubjects: [],
+  prereqs: [],
+  todoPrereqs: [],
+});
 
+const createObjectiveContData = (): ObjectiveContribution => ({
+  title: "",
+  summary: "",
+  targets: [
+    "arithmetic-introduction",
+    "algebra-how-to-express-equations",
+    "calculus-introduction",
+    "vectors-introduction",
+    "mechanics-how-to-apply-newtons-laws",
+  ],
+  featured: "",
+  subObjectives: [],
+});
+
+export default function ContributionFlow({ type, setType }: PropTypes) {
+  const [guideContData, setGuideContData] =
+    useState<GuideContribution>(createGuideContData);
   const [objectiveContData, setObjectiveContData] =
-    useState<ObjectiveContribution>({
-      title: "",
-      summary: "",
-      targets: [
-        "arithmetic-introduction",
-        "algebra-how-to-express-equations",
-        "calculus-introduction",
-        "vectors-introduction",
-        "mechanics-how-to-apply-newtons-laws",
-      ],
-      featured: "",
-      subObjectives: [],
-    });
+    useState<ObjectiveContribution>(createObjectiveContData);
 
   const StepperInstance = useMemo(() => {
     if (!type) {
@@ -104,7 +108,11 @@ function Inner({
   setObjectiveContData: Dispatch<SetStateAction<ObjectiveContribution>>;
 }) {
   const pickType = (value: ContributionType) => {
-    setType(value);
+    if (type !== value) {
+      setGuideContData(createGuideContData());
+      setObjectiveContData(createObjectiveContData());
+      setType(value);
+    }
 
     requestAnimationFrame(() => {
       switch (value) {


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->
If the user selects a contribution types starts to fill in the fields, then goes back and changes the type the fields data does not reset.

This change resets the initial contribution data when contribution type changes.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [X] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
