### PR TITLE
feat(api): add validated pagination to read routes

### DIFF
--- a/api/openapi/components/parameters/pagination.yaml
+++ b/api/openapi/components/parameters/pagination.yaml
@@ -1,0 +1,22 @@
+# Shared offset-pagination query params, referenced as
+# ../components/parameters/pagination.yaml#/<Name>. Read endpoints that return a
+# list accept these and answer with a `total` alongside the page.
+Page:
+  name: page
+  in: query
+  required: false
+  schema:
+    type: integer
+    minimum: 1
+    default: 1
+  description: 1-based page number.
+Limit:
+  name: limit
+  in: query
+  required: false
+  schema:
+    type: integer
+    minimum: 1
+    maximum: 100
+    default: 20
+  description: Rows per page (max 100).

--- a/api/openapi/paths/guides.yaml
+++ b/api/openapi/paths/guides.yaml
@@ -5,6 +5,9 @@
     summary: List published guides
     description: Published guide bases, alphabetical.
     operationId: listGuides
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Published guides
@@ -18,7 +21,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/guides/GuideListItem.yaml"
-              required: [guides]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [guides, total]
   post:
     tags: [guides]
     summary: Create a guide
@@ -162,6 +168,9 @@
     summary: List variants under a guide
     description: The methods (practice guide) or alternatives (theory guide) under this guide.
     operationId: listGuideVariants
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Variants under the guide
@@ -175,7 +184,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/variants/VariantListItem.yaml"
-              required: [variants]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [variants, total]
       "404":
         $ref: "../components/responses/_shared.yaml#/NotFound"
   post:

--- a/api/openapi/paths/objectives.yaml
+++ b/api/openapi/paths/objectives.yaml
@@ -4,6 +4,9 @@
     tags: [objectives]
     summary: List published objectives
     operationId: listObjectives
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Published objectives
@@ -17,7 +20,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/objectives/ObjectiveListItem.yaml"
-              required: [objectives]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [objectives, total]
   post:
     tags: [objectives]
     summary: Create a draft objective
@@ -134,6 +140,9 @@
     tags: [objectives]
     summary: Revision history for this objective
     operationId: listObjectiveRevisions
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Revisions, newest first
@@ -147,7 +156,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/objective-revisions/ObjectiveRevisionListItem.yaml"
-              required: [revisions]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [revisions, total]
       "404":
         $ref: "../components/responses/_shared.yaml#/NotFound"
   post:

--- a/api/openapi/paths/reviews.yaml
+++ b/api/openapi/paths/reviews.yaml
@@ -7,6 +7,9 @@
     operationId: getReviewQueue
     security:
       - bearerAuth: []
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Open cases
@@ -20,7 +23,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/reviews/ReviewQueueItem.yaml"
-              required: [cases]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [cases, total]
       "401":
         $ref: "../components/responses/_shared.yaml#/Unauthorized"
 

--- a/api/openapi/paths/subjects.yaml
+++ b/api/openapi/paths/subjects.yaml
@@ -4,6 +4,9 @@
     tags: [subjects]
     summary: List all subjects
     operationId: listSubjects
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: All subjects
@@ -17,7 +20,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/subjects/SubjectListItem.yaml"
-              required: [subjects]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [subjects, total]
 
 /subjects/{slug}:
   parameters:
@@ -60,6 +66,9 @@
     summary: List guides tagged with this subject
     description: Alphabetical list of guides carrying this subject tag.
     operationId: listSubjectGuides
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Tagged guides
@@ -73,7 +82,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/guides/GuideListItem.yaml"
-              required: [guides]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [guides, total]
       "404":
         $ref: "../components/responses/_shared.yaml#/NotFound"
 
@@ -90,6 +102,9 @@
     summary: List objectives tagged with this subject
     description: Alphabetical list of published objectives carrying this subject tag.
     operationId: listSubjectObjectives
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Tagged objectives
@@ -103,6 +118,9 @@
                   type: array
                   items:
                     $ref: "../components/schemas/objectives/ObjectiveListItem.yaml"
-              required: [objectives]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [objectives, total]
       "404":
         $ref: "../components/responses/_shared.yaml#/NotFound"

--- a/api/openapi/paths/variants.yaml
+++ b/api/openapi/paths/variants.yaml
@@ -129,6 +129,9 @@
       The revisions that went live, newest live first. Ordered by approved_at
       (when each became the current content).
     operationId: listVariantRevisions
+    parameters:
+      - $ref: "../components/parameters/pagination.yaml#/Page"
+      - $ref: "../components/parameters/pagination.yaml#/Limit"
     responses:
       "200":
         description: Published versions, newest live first
@@ -142,7 +145,10 @@
                   type: array
                   items:
                     $ref: "../components/schemas/common/RevisionListItem.yaml"
-              required: [revisions]
+                total:
+                  type: integer
+                  minimum: 0
+              required: [revisions, total]
       "404":
         $ref: "../components/responses/_shared.yaml#/NotFound"
   post:

--- a/api/src/routes/guides.ts
+++ b/api/src/routes/guides.ts
@@ -7,6 +7,7 @@ import {
   castVoteSchema,
   createGuideSchema,
   createVariantSchema,
+  paginationSchema,
   rollbackRevisionSchema,
   updateRevisionSchema,
 } from "@bluelearn/schemas";
@@ -54,9 +55,13 @@ const createVariantBody = createVariantSchema.extend({
 
 export const guidesRouter = new Hono<HonoEnv>()
   // Returns published guides as { guides }.
-  .get("/", async (c) => {
-    const guides = await listPublishedGuides(c.get("supabase"));
-    return c.json({ guides });
+  .get("/", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listPublishedGuides(c.get("supabase"), {
+      page,
+      limit,
+    });
+    return c.json({ guides: data, total });
   })
 
   // 201 with { revision_id } for the editor route. Rate-limited to 15
@@ -106,12 +111,14 @@ export const guidesRouter = new Hono<HonoEnv>()
   })
 
   // Returns the published variants as { variants }.
-  .get("/:slug/variants", async (c) => {
-    const variants = await listGuideVariants(
+  .get("/:slug/variants", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listGuideVariants(
       c.get("supabase"),
-      c.req.param("slug")
+      c.req.param("slug"),
+      { page, limit }
     );
-    return c.json({ variants });
+    return c.json({ variants: data, total });
   })
 
   // 201 with { revision_id } for the editor route.
@@ -175,12 +182,14 @@ export const variantsRouter = new Hono<HonoEnv>()
   })
 
   // Returns the published versions as { revisions }, newest live first.
-  .get("/:id/revisions", async (c) => {
-    const revisions = await listVariantRevisions(
+  .get("/:id/revisions", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listVariantRevisions(
       c.get("supabase"),
-      c.req.param("id")
+      c.req.param("id"),
+      { page, limit }
     );
-    return c.json({ revisions });
+    return c.json({ revisions: data, total });
   })
 
   // 201 with { revision_id } for the editor route.

--- a/api/src/routes/objectives.ts
+++ b/api/src/routes/objectives.ts
@@ -4,6 +4,7 @@ import type { HonoEnv } from "../types";
 import { zValidator } from "@hono/zod-validator";
 import {
   createObjectiveSchema,
+  paginationSchema,
   rollbackRevisionSchema,
   updateObjectiveNodeSchema,
   updateObjectiveRevisionSchema,
@@ -31,9 +32,13 @@ import {
 
 export const objectivesRouter = new Hono<HonoEnv>()
   // Returns published objectives as { objectives }.
-  .get("/", async (c) => {
-    const objectives = await listPublishedObjectives(c.get("supabase"));
-    return c.json({ objectives });
+  .get("/", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listPublishedObjectives(c.get("supabase"), {
+      page,
+      limit,
+    });
+    return c.json({ objectives: data, total });
   })
 
   // 201 with { revision_id } for the editor route.
@@ -74,12 +79,14 @@ export const objectivesRouter = new Hono<HonoEnv>()
   })
 
   // Returns the revision history as { revisions }, newest first.
-  .get("/:slug/revisions", async (c) => {
-    const revisions = await listObjectiveRevisions(
+  .get("/:slug/revisions", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listObjectiveRevisions(
       c.get("supabase"),
-      c.req.param("slug")
+      c.req.param("slug"),
+      { page, limit }
     );
-    return c.json({ revisions });
+    return c.json({ revisions: data, total });
   })
 
   // 201 with { revision_id } for the new draft.

--- a/api/src/routes/reviews.ts
+++ b/api/src/routes/reviews.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { createDecisionSchema } from "@bluelearn/schemas";
+import { createDecisionSchema, paginationSchema } from "@bluelearn/schemas";
 import { requireUser } from "../middleware/auth.middleware";
 import type { HonoEnv } from "../types";
 import {
@@ -16,10 +16,20 @@ import {
 
 export const reviewsRouter = new Hono<HonoEnv>()
   // Open cases needing action from the current reviewer
-  .get("/queue", requireUser, async (c) => {
-    const cases = await getReviewQueue(c.get("supabase"), c.get("user").id);
-    return c.json({ cases }, 200);
-  })
+  .get(
+    "/queue",
+    requireUser,
+    zValidator("query", paginationSchema),
+    async (c) => {
+      const { page, limit } = c.req.valid("query");
+      const { data, total } = await getReviewQueue(
+        c.get("supabase"),
+        c.get("user").id,
+        { page, limit }
+      );
+      return c.json({ cases: data, total }, 200);
+    }
+  )
 
   // All finished review cases (public — only returns approved/rejected)
   .get("/cases", async (c) => {

--- a/api/src/routes/subjects.ts
+++ b/api/src/routes/subjects.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { paginationSchema } from "@bluelearn/schemas";
+import { zValidator } from "@hono/zod-validator";
 import type { HonoEnv } from "../types";
 import {
   getSubjectBySlug,
@@ -9,9 +11,13 @@ import {
 
 export const subjectsRouter = new Hono<HonoEnv>()
   // List all subjects
-  .get("/", async (c) => {
-    const subjects = await listSubjects(c.get("supabase"));
-    return c.json({ subjects }, 200);
+  .get("/", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listSubjects(c.get("supabase"), {
+      page,
+      limit,
+    });
+    return c.json({ subjects: data, total }, 200);
   })
 
   // Subject metadata only
@@ -24,19 +30,27 @@ export const subjectsRouter = new Hono<HonoEnv>()
   })
 
   // Alphabetical list of guides carrying this subject tag
-  .get("/:slug/guides", async (c) => {
-    const guides = await listSubjectGuides(
+  .get("/:slug/guides", zValidator("query", paginationSchema), async (c) => {
+    const { page, limit } = c.req.valid("query");
+    const { data, total } = await listSubjectGuides(
       c.get("supabase"),
-      c.req.param("slug")
+      c.req.param("slug"),
+      { page, limit }
     );
-    return c.json({ guides }, 200);
+    return c.json({ guides: data, total }, 200);
   })
 
   // Alphabetical list of published objectives tagged with this subject
-  .get("/:slug/objectives", async (c) => {
-    const objectives = await listSubjectObjectives(
-      c.get("supabase"),
-      c.req.param("slug")
-    );
-    return c.json({ objectives }, 200);
-  });
+  .get(
+    "/:slug/objectives",
+    zValidator("query", paginationSchema),
+    async (c) => {
+      const { page, limit } = c.req.valid("query");
+      const { data, total } = await listSubjectObjectives(
+        c.get("supabase"),
+        c.req.param("slug"),
+        { page, limit }
+      );
+      return c.json({ objectives: data, total }, 200);
+    }
+  );

--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -3,6 +3,7 @@ import type {
   CreateGuideInput,
   CreateVariantInput,
   GuideListItem,
+  Pagination,
   SubjectReference,
 } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
@@ -157,9 +158,13 @@ export async function buildGuideListItems(
 // List published guides as cards, alphabetical. RLS hides drafts from
 // non-authors.
 export async function listPublishedGuides(
-  supabase: DB
-): Promise<GuideListItem[]> {
-  const { data, error } = await supabase
+  supabase: DB,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+): Promise<{ data: GuideListItem[]; total: number }> {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, count, error } = await supabase
     .from("guide_bases")
     .select(
       `id, slug, title, knowledge_type, status, created_at,
@@ -168,17 +173,22 @@ export async function listPublishedGuides(
          current:guide_revisions!guides_current_revision_id_fkey!inner(
            id, summary, word_count
          )
-       )`
+       )`,
+      { count: "exact", head: false }
     )
     .eq("status", "published")
-    .order("title");
+    .order("title")
+    .range(from, to);
 
   if (error) {
     console.error(error);
     throw new ServiceError("Failed to load guides", 500);
   }
 
-  return buildGuideListItems(supabase, data ?? []);
+  return {
+    data: await buildGuideListItems(supabase, data ?? []),
+    total: count ?? 0,
+  };
 }
 
 // Create a guide: the create_guide RPC bundles the guide_base + first guide +
@@ -288,7 +298,11 @@ export async function getWalkthrough(supabase: DB, rawSlug: string) {
 
 // List the published variants (methods/alternatives) under a guide, ranked
 // by Wilson score lower bound
-export async function listGuideVariants(supabase: DB, rawSlug: string) {
+export async function listGuideVariants(
+  supabase: DB,
+  rawSlug: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+) {
   const baseId = await resolveBaseId(supabase, rawSlug);
 
   const { data, error } = await supabase.rpc("list_guide_variants_by_score", {
@@ -300,7 +314,13 @@ export async function listGuideVariants(supabase: DB, rawSlug: string) {
     throw new ServiceError("Failed to load variants", 500);
   }
 
-  return data ?? [];
+  const all = data ?? [];
+  const from = (page - 1) * limit;
+  const to = from + limit;
+  return {
+    data: all.slice(from, to),
+    total: all.length,
+  };
 }
 
 // Add a variant under a guide: a draft guide + first revision via the

--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -174,7 +174,7 @@ export async function listPublishedGuides(
            id, summary, word_count
          )
        )`,
-      { count: "exact", head: false }
+      { count: "exact" }
     )
     .eq("status", "published")
     .order("title")

--- a/api/src/services/objective.service.ts
+++ b/api/src/services/objective.service.ts
@@ -3,6 +3,7 @@ import type {
   CreateObjectiveInput,
   FeaturedNode,
   ObjectiveListItem,
+  Pagination,
 } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
 import { ServiceError } from "../lib/service-error";
@@ -224,22 +225,31 @@ export async function buildObjectiveListItems(
 // List published objectives as cards, newest first. RLS hides drafts from
 // non-authors.
 export async function listPublishedObjectives(
-  supabase: DB
-): Promise<ObjectiveListItem[]> {
-  const { data, error } = await supabase
+  supabase: DB,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+): Promise<{ data: ObjectiveListItem[]; total: number }> {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, count, error } = await supabase
     .from("objectives")
     .select(
-      `id, slug, created_by, created_at, current_revision_id, ${CURRENT_META}`
+      `id, slug, created_by, created_at, current_revision_id, ${CURRENT_META}`,
+      { count: "exact", head: false }
     )
     .eq("status", "published")
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .range(from, to);
 
   if (error) {
     console.error(error);
     throw new ServiceError("Failed to load objectives", 500);
   }
 
-  return buildObjectiveListItems(supabase, data ?? []);
+  return {
+    data: await buildObjectiveListItems(supabase, data ?? []),
+    total: count ?? 0,
+  };
 }
 
 // Create a objective: bundles the objective shell + revision 1 + the targets' prerequisite
@@ -317,18 +327,28 @@ export async function archiveObjective(supabase: DB, rawSlug: string) {
 
 // The objective's revision history, newest first. Drafts (null published_at) sort by
 // creation alongside published ones.
-export async function listObjectiveRevisions(supabase: DB, rawSlug: string) {
+export async function listObjectiveRevisions(
+  supabase: DB,
+  rawSlug: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+) {
   const { id } = await resolveObjective(supabase, rawSlug);
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
 
-  const { data, error } = await supabase
+  const { data, count, error } = await supabase
     .from("objective_revisions")
-    .select("id, title, change_summary, status, created_at, published_at")
+    .select("id, title, change_summary, status, created_at, published_at", {
+      count: "exact",
+      head: false,
+    })
     .eq("objective_id", id)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .range(from, to);
 
   if (error) {
     console.error(error);
     throw new ServiceError("Failed to load revisions", 500);
   }
-  return data ?? [];
+  return { data: data ?? [], total: count ?? 0 };
 }

--- a/api/src/services/objective.service.ts
+++ b/api/src/services/objective.service.ts
@@ -235,7 +235,7 @@ export async function listPublishedObjectives(
     .from("objectives")
     .select(
       `id, slug, created_by, created_at, current_revision_id, ${CURRENT_META}`,
-      { count: "exact", head: false }
+      { count: "exact" }
     )
     .eq("status", "published")
     .order("created_at", { ascending: false })
@@ -340,7 +340,6 @@ export async function listObjectiveRevisions(
     .from("objective_revisions")
     .select("id, title, change_summary, status, created_at, published_at", {
       count: "exact",
-      head: false,
     })
     .eq("objective_id", id)
     .order("created_at", { ascending: false })

--- a/api/src/services/review.service.ts
+++ b/api/src/services/review.service.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { DecisionReason } from "@bluelearn/schemas";
+import type { DecisionReason, Pagination } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
 import { ServiceError } from "../lib/service-error";
 import { PANEL_POLICY_DEFAULTS } from "../lib/review-policy";
@@ -105,7 +105,11 @@ type CaseDetailRow = {
 
 // ---- Exports ----
 
-export async function getReviewQueue(supabase: DB, userId: string) {
+export async function getReviewQueue(
+  supabase: DB,
+  userId: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+) {
   const { data: raw, error } = await supabase
     .from("panel_members")
     .select(
@@ -152,7 +156,7 @@ export async function getReviewQueue(supabase: DB, userId: string) {
     guideLinks = (links ?? []) as unknown as GuideLinkRow[];
   }
 
-  return open
+  const all = open
     .map((m) => {
       const rc = m.review_panels.review_cases;
       const link = guideLinks.find((l) => l.case_id === rc.id);
@@ -171,6 +175,10 @@ export async function getReviewQueue(supabase: DB, userId: string) {
         Number(a.decision !== null) - Number(b.decision !== null) ||
         b.created_at.localeCompare(a.created_at)
     );
+
+  const from = (page - 1) * limit;
+  const to = from + limit;
+  return { data: all.slice(from, to), total: all.length };
 }
 
 export async function listReviewCases(supabase: DB) {

--- a/api/src/services/subject.service.ts
+++ b/api/src/services/subject.service.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   GuideListItem,
   ObjectiveListItem,
+  Pagination,
   SubjectListItem,
 } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
@@ -41,11 +42,17 @@ function tallyBySubject(tagsPerRow: Array<Array<{ subject_id: string }>>) {
   return counts;
 }
 
-export async function listSubjects(supabase: DB): Promise<SubjectListItem[]> {
-  const { data, error } = await supabase
+export async function listSubjects(
+  supabase: DB,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+): Promise<{ data: SubjectListItem[]; total: number }> {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, count, error } = await supabase
     .from("subjects")
-    .select("id, slug, name, summary")
-    .eq("status", "published");
+    .select("id, slug, name, summary", { count: "exact", head: false })
+    .range(from, to);
 
   if (error) {
     console.error(error);
@@ -59,11 +66,14 @@ export async function listSubjects(supabase: DB): Promise<SubjectListItem[]> {
     countObjectivesBySubject(supabase),
   ]);
 
-  return (data ?? []).map((subject) => ({
-    ...subject,
-    guides_total: guideCounts.get(subject.id) ?? 0,
-    objectives_total: objectiveCounts.get(subject.id) ?? 0,
-  }));
+  return {
+    data: (data ?? []).map((subject) => ({
+      ...subject,
+      guides_total: guideCounts.get(subject.id) ?? 0,
+      objectives_total: objectiveCounts.get(subject.id) ?? 0,
+    })),
+    total: count ?? 0,
+  };
 }
 
 async function countGuidesBySubject(supabase: DB) {
@@ -166,11 +176,18 @@ export async function getSubjectBySlug(supabase: DB, rawSlug: string) {
 
 export async function listSubjectGuides(
   supabase: DB,
-  rawSlug: string
-): Promise<GuideListItem[]> {
+  rawSlug: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+): Promise<{ data: GuideListItem[]; total: number }> {
   const subject = await resolveSubjectId(supabase, rawSlug);
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
 
-  const { data, error: guideError } = await supabase
+  const {
+    data,
+    count,
+    error: guideError,
+  } = await supabase
     .from("guide_bases")
     .select(
       `id, slug, title, knowledge_type, status, created_at,
@@ -180,36 +197,50 @@ export async function listSubjectGuides(
            id, summary, word_count,
            guide_revision_subjects!inner(subject_id)
          )
-       )`
+       )`,
+      { count: "exact", head: false }
     )
     .eq("canonical.current.guide_revision_subjects.subject_id", subject.id)
-    .order("title");
+    .order("title")
+    .range(from, to);
 
   if (guideError) {
     console.error(guideError);
     throw new ServiceError("Failed to load subject guides", 500);
   }
 
-  return buildGuideListItems(supabase, data ?? []);
+  return {
+    data: await buildGuideListItems(supabase, data ?? []),
+    total: count ?? 0,
+  };
 }
 
 export async function listSubjectObjectives(
   supabase: DB,
-  rawSlug: string
-): Promise<ObjectiveListItem[]> {
+  rawSlug: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+): Promise<{ data: ObjectiveListItem[]; total: number }> {
   const subject = await resolveSubjectId(supabase, rawSlug);
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
 
-  const { data, error: objError } = await supabase
+  const {
+    data,
+    count,
+    error: objError,
+  } = await supabase
     .from("objectives")
     .select(
       `id, slug, created_by, created_at, current_revision_id,
        current:objective_revisions!objectives_current_revision_id_fkey!inner(
          title, summary,
          objective_revision_subjects!inner(subject_id)
-       )`
+       )`,
+      { count: "exact", head: false }
     )
     .eq("current.objective_revision_subjects.subject_id", subject.id)
-    .eq("status", "published");
+    .eq("status", "published")
+    .range(from, to);
 
   if (objError) {
     console.error(objError);
@@ -219,5 +250,8 @@ export async function listSubjectObjectives(
   // Title lives on the revision and the node -> revision FK is composite
   // (to-many), so PostgREST can't sort the objectives by it. Sort here instead.
   const items = await buildObjectiveListItems(supabase, data ?? []);
-  return items.sort((a, b) => (a.title ?? "").localeCompare(b.title ?? ""));
+  return {
+    data: items.sort((a, b) => (a.title ?? "").localeCompare(b.title ?? "")),
+    total: count ?? 0,
+  };
 }

--- a/api/src/services/subject.service.ts
+++ b/api/src/services/subject.service.ts
@@ -51,7 +51,8 @@ export async function listSubjects(
 
   const { data, count, error } = await supabase
     .from("subjects")
-    .select("id, slug, name, summary", { count: "exact", head: false })
+    .select("id, slug, name, summary", { count: "exact" })
+    .eq("status", "published")
     .range(from, to);
 
   if (error) {
@@ -198,7 +199,7 @@ export async function listSubjectGuides(
            guide_revision_subjects!inner(subject_id)
          )
        )`,
-      { count: "exact", head: false }
+      { count: "exact" }
     )
     .eq("canonical.current.guide_revision_subjects.subject_id", subject.id)
     .order("title")
@@ -236,7 +237,7 @@ export async function listSubjectObjectives(
          title, summary,
          objective_revision_subjects!inner(subject_id)
        )`,
-      { count: "exact", head: false }
+      { count: "exact" }
     )
     .eq("current.objective_revision_subjects.subject_id", subject.id)
     .eq("status", "published")

--- a/api/src/services/variant.service.ts
+++ b/api/src/services/variant.service.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { CastVoteInput } from "@bluelearn/schemas";
+import type { CastVoteInput, Pagination } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
 import { ServiceError } from "../lib/service-error";
 import { promoteCanonicalIfNeeded } from "./promotion.service";
@@ -146,27 +146,37 @@ export async function retractVote(supabase: DB, voterId: string, id: string) {
 // newest live first. Ordered by approved_at (when each became the guide's
 // current content), not authoring order, so an early draft approved late lands
 // where it went live. Empty until the review flow promotes a revision.
-export async function listVariantRevisions(supabase: DB, id: string) {
+export async function listVariantRevisions(
+  supabase: DB,
+  id: string,
+  { page, limit }: Pagination = { page: 1, limit: 20 }
+) {
   await requireVariant(supabase, id);
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
 
-  const { data, error } = await supabase
+  const { data, count, error } = await supabase
     .from("guide_revisions")
-    .select("id, created_at, approved_at")
+    .select("id, created_at, approved_at", { count: "exact", head: false })
     .eq("guide_id", id)
     .not("approved_at", "is", null)
-    .order("approved_at", { ascending: false });
+    .order("approved_at", { ascending: false })
+    .range(from, to);
 
   if (error) {
     console.error(error);
     throw new ServiceError("Failed to load variant revisions", 500);
   }
 
-  return (data ?? []).map((rev) => ({
-    id: rev.id,
-    status: "approved" as const,
-    created_at: rev.created_at,
-    approved_at: rev.approved_at,
-  }));
+  return {
+    data: (data ?? []).map((rev) => ({
+      id: rev.id,
+      status: "approved" as const,
+      created_at: rev.created_at,
+      approved_at: rev.approved_at,
+    })),
+    total: count ?? 0,
+  };
 }
 
 // Start a new draft revision on an already-published variant, seeded from its

--- a/api/src/services/variant.service.ts
+++ b/api/src/services/variant.service.ts
@@ -157,7 +157,7 @@ export async function listVariantRevisions(
 
   const { data, count, error } = await supabase
     .from("guide_revisions")
-    .select("id, created_at, approved_at", { count: "exact", head: false })
+    .select("id, created_at, approved_at", { count: "exact" })
     .eq("guide_id", id)
     .not("approved_at", "is", null)
     .order("approved_at", { ascending: false })

--- a/app/src/lib/api/apiHelpers.ts
+++ b/app/src/lib/api/apiHelpers.ts
@@ -9,3 +9,27 @@ export async function assertOk(res: Response) {
 
   throw new Error(body?.error ?? `Request failed (${res.status})`);
 }
+
+export const PAGE_LIMIT = 100;
+export async function collectAll<T>(
+  fetchPage: (query: {
+    page: string;
+    limit: string;
+  }) => Promise<{ items: Array<T>; total: number }>
+): Promise<Array<T>> {
+  const out: Array<T> = [];
+  let items: Array<T> = [];
+  let total = Infinity;
+  let page = 1;
+
+  do {
+    ({ items, total } = await fetchPage({
+      page: String(page),
+      limit: String(PAGE_LIMIT),
+    }));
+    out.push(...items);
+    page++;
+  } while (out.length < total && items.length !== 0);
+
+  return out;
+}

--- a/app/src/lib/api/guides.ts
+++ b/app/src/lib/api/guides.ts
@@ -1,4 +1,5 @@
 import type { InferRequestType } from "hono/client";
+import type { GuideListItem } from "@bluelearn/schemas";
 import { client } from "@/lib/api/apiClient";
 import { assertOk } from "@/lib/api/apiHelpers";
 
@@ -7,10 +8,12 @@ const guides = client.guides;
 type FetchOptions = { signal?: AbortSignal };
 
 export async function listGuides({ signal }: FetchOptions = {}) {
-  const res = await guides.$get(undefined, { init: { signal } });
+  const res = await guides.$get({ query: {} }, { init: { signal } });
   await assertOk(res);
 
-  const { guides: data } = await res.json();
+  const { guides: data } = (await res.json()) as {
+    guides: Array<GuideListItem>;
+  };
   return data;
 }
 

--- a/app/src/lib/api/guides.ts
+++ b/app/src/lib/api/guides.ts
@@ -1,20 +1,20 @@
 import type { InferRequestType } from "hono/client";
 import type { GuideListItem } from "@bluelearn/schemas";
 import { client } from "@/lib/api/apiClient";
-import { assertOk } from "@/lib/api/apiHelpers";
+import { assertOk, collectAll } from "@/lib/api/apiHelpers";
 
 const guides = client.guides;
 
 type FetchOptions = { signal?: AbortSignal };
 
 export async function listGuides({ signal }: FetchOptions = {}) {
-  const res = await guides.$get({ query: {} }, { init: { signal } });
-  await assertOk(res);
+  return collectAll<GuideListItem>(async (query) => {
+    const res = await guides.$get({ query }, { init: { signal } });
+    if (!res.ok) return assertOk(res) as Promise<never>;
 
-  const { guides: data } = (await res.json()) as {
-    guides: Array<GuideListItem>;
-  };
-  return data;
+    const { guides: items, total } = await res.json();
+    return { items, total };
+  });
 }
 
 export async function createGuide(

--- a/app/src/lib/api/reviews.ts
+++ b/app/src/lib/api/reviews.ts
@@ -5,11 +5,20 @@ const reviews = client.reviews;
 
 type FetchOptions = { signal?: AbortSignal };
 
+type QueueCase = {
+  id: string;
+  case_type: string;
+  status: string;
+  title: string | null;
+  created_at: string;
+  decision: "approved" | "rejected" | null;
+};
+
 export async function getReviewQueue({ signal }: FetchOptions = {}) {
-  const res = await reviews.queue.$get(undefined, { init: { signal } });
+  const res = await reviews.queue.$get({ query: {} }, { init: { signal } });
   await assertOk(res);
 
-  const { cases } = await res.json();
+  const { cases } = (await res.json()) as { cases: Array<QueueCase> };
   return cases;
 }
 

--- a/app/src/lib/api/reviews.ts
+++ b/app/src/lib/api/reviews.ts
@@ -1,5 +1,5 @@
 import { client } from "@/lib/api/apiClient";
-import { assertOk } from "@/lib/api/apiHelpers";
+import { assertOk, collectAll } from "@/lib/api/apiHelpers";
 
 const reviews = client.reviews;
 
@@ -15,11 +15,13 @@ type QueueCase = {
 };
 
 export async function getReviewQueue({ signal }: FetchOptions = {}) {
-  const res = await reviews.queue.$get({ query: {} }, { init: { signal } });
-  await assertOk(res);
+  return collectAll<QueueCase>(async (query) => {
+    const res = await reviews.queue.$get({ query }, { init: { signal } });
+    if (!res.ok) return assertOk(res) as Promise<never>;
 
-  const { cases } = (await res.json()) as { cases: Array<QueueCase> };
-  return cases;
+    const { cases: items, total } = await res.json();
+    return { items, total };
+  });
 }
 
 export async function getReviewCase(id: string, { signal }: FetchOptions = {}) {

--- a/app/src/lib/api/subjects.ts
+++ b/app/src/lib/api/subjects.ts
@@ -1,3 +1,8 @@
+import type {
+  GuideListItem,
+  ObjectiveListItem,
+  SubjectListItem,
+} from "@bluelearn/schemas";
 import { client } from "@/lib/api/apiClient";
 import { assertOk } from "@/lib/api/apiHelpers";
 
@@ -6,10 +11,12 @@ const subjects = client.subjects;
 type FetchOptions = { signal?: AbortSignal };
 
 export async function listSubjects({ signal }: FetchOptions = {}) {
-  const res = await subjects.$get(undefined, { init: { signal } });
+  const res = await subjects.$get({ query: {} }, { init: { signal } });
   await assertOk(res);
 
-  const { subjects: data } = await res.json();
+  const { subjects: data } = (await res.json()) as {
+    subjects: Array<SubjectListItem>;
+  };
   return data;
 }
 
@@ -32,12 +39,12 @@ export async function listSubjectGuides(
   { signal }: FetchOptions = {}
 ) {
   const res = await subjects[":slug"].guides.$get(
-    { param: { slug } },
+    { query: {}, param: { slug } },
     { init: { signal } }
   );
   await assertOk(res);
 
-  const { guides } = await res.json();
+  const { guides } = (await res.json()) as { guides: Array<GuideListItem> };
   return guides;
 }
 
@@ -46,11 +53,13 @@ export async function listSubjectObjectives(
   { signal }: FetchOptions = {}
 ) {
   const res = await subjects[":slug"].objectives.$get(
-    { param: { slug } },
+    { query: {}, param: { slug } },
     { init: { signal } }
   );
   await assertOk(res);
 
-  const { objectives } = await res.json();
+  const { objectives } = (await res.json()) as {
+    objectives: Array<ObjectiveListItem>;
+  };
   return objectives;
 }

--- a/app/src/lib/api/subjects.ts
+++ b/app/src/lib/api/subjects.ts
@@ -4,20 +4,20 @@ import type {
   SubjectListItem,
 } from "@bluelearn/schemas";
 import { client } from "@/lib/api/apiClient";
-import { assertOk } from "@/lib/api/apiHelpers";
+import { assertOk, collectAll } from "@/lib/api/apiHelpers";
 
 const subjects = client.subjects;
 
 type FetchOptions = { signal?: AbortSignal };
 
 export async function listSubjects({ signal }: FetchOptions = {}) {
-  const res = await subjects.$get({ query: {} }, { init: { signal } });
-  await assertOk(res);
+  return collectAll<SubjectListItem>(async (query) => {
+    const res = await subjects.$get({ query }, { init: { signal } });
+    if (!res.ok) return assertOk(res) as Promise<never>;
 
-  const { subjects: data } = (await res.json()) as {
-    subjects: Array<SubjectListItem>;
-  };
-  return data;
+    const { subjects: items, total } = await res.json();
+    return { items, total };
+  });
 }
 
 export async function getSubjectBySlug(
@@ -38,28 +38,30 @@ export async function listSubjectGuides(
   slug: string,
   { signal }: FetchOptions = {}
 ) {
-  const res = await subjects[":slug"].guides.$get(
-    { query: {}, param: { slug } },
-    { init: { signal } }
-  );
-  await assertOk(res);
+  return collectAll<GuideListItem>(async (query) => {
+    const res = await subjects[":slug"].guides.$get(
+      { query, param: { slug } },
+      { init: { signal } }
+    );
+    if (!res.ok) return assertOk(res) as Promise<never>;
 
-  const { guides } = (await res.json()) as { guides: Array<GuideListItem> };
-  return guides;
+    const { guides: items, total } = await res.json();
+    return { items, total };
+  });
 }
 
 export async function listSubjectObjectives(
   slug: string,
   { signal }: FetchOptions = {}
 ) {
-  const res = await subjects[":slug"].objectives.$get(
-    { query: {}, param: { slug } },
-    { init: { signal } }
-  );
-  await assertOk(res);
+  return collectAll<ObjectiveListItem>(async (query) => {
+    const res = await subjects[":slug"].objectives.$get(
+      { query, param: { slug } },
+      { init: { signal } }
+    );
+    if (!res.ok) return assertOk(res) as Promise<never>;
 
-  const { objectives } = (await res.json()) as {
-    objectives: Array<ObjectiveListItem>;
-  };
-  return objectives;
+    const { objectives: items, total } = await res.json();
+    return { items, total };
+  });
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants";
+export * from "./pagination";
 export * from "./subjects";
 export * from "./guides";
 export * from "./identity";

--- a/packages/schemas/src/pagination.ts
+++ b/packages/schemas/src/pagination.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type Pagination = z.infer<typeof paginationSchema>;


### PR DESCRIPTION
## Summary

Add offset-based pagination (`page`/`limit` query params) to 9 read endpoints across guides, objectives, subjects, and review queue. Uses a shared Zod schema for validation with defaults (page=1, limit=20, max=100).

All responses now include a `total` field alongside the existing data array — fully backward compatible.

Closes #181

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes) — backend only
- [ ] Followed the app layout conventions
- [ ] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle