### PR TITLE
feat(api): rate limit all write routes and public reads

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createClient } from "@supabase/supabase-js";
 import { supabaseMiddleware } from "./middleware/auth.middleware";
+import { rateLimitMiddleware } from "./middleware/rate-limit.middleware";
+import { READ } from "./middleware/rateLimits";
 import { ServiceError } from "./lib/service-error";
 import { assemblePendingPanels } from "./services/review.service";
 import { promoteAllCanonicals } from "./services/promotion.service";
@@ -26,6 +28,7 @@ import { avatarRouter } from "./routes/avatar";
 
 const app = new Hono<HonoEnv>()
   .use((c, next) => cors({ origin: c.env.APP_URL })(c, next))
+  .use(rateLimitMiddleware({ ...READ, bucket: "global-read" }))
   .use(supabaseMiddleware())
   .get("/", (c) => c.json({ ok: true }))
 

--- a/api/src/middleware/rate-limit.middleware.ts
+++ b/api/src/middleware/rate-limit.middleware.ts
@@ -4,6 +4,8 @@ import type { HonoEnv } from "../types";
 type RateLimitOptions = {
   windowSeconds: number;
   max: number;
+  bucket: string;
+  keyBy?: "user" | "ip";
   message?: string;
 };
 
@@ -71,12 +73,17 @@ async function hitDurableObject(
 export function rateLimitMiddleware(
   options: RateLimitOptions
 ): MiddlewareHandler<HonoEnv> {
+  const keyBy = options.keyBy ?? "user";
   return async (c, next) => {
-    const user = c.get("user");
-    // Defensive -- requireUser should always run first.
-    if (!user) return c.json({ error: "Unauthorized" }, 401);
-
-    const key = `user:${user.id}`;
+    let key: string;
+    if (keyBy === "ip") {
+      const ip = c.req.header("CF-Connecting-IP") ?? "unknown";
+      key = `ip:${ip}:${options.bucket}`;
+    } else {
+      const user = c.get("user");
+      if (!user) return c.json({ error: "Unauthorized" }, 401);
+      key = `user:${user.id}:${options.bucket}`;
+    }
 
     const { count, resetAt } = c.env.RATE_LIMITER
       ? await hitDurableObject(c.env.RATE_LIMITER, key, options.windowSeconds)

--- a/api/src/middleware/rateLimits.ts
+++ b/api/src/middleware/rateLimits.ts
@@ -1,0 +1,6 @@
+export const CREATE = { windowSeconds: 86_400, max: 20 } as const;
+export const CONTRIBUTION = { windowSeconds: 3_600, max: 60 } as const;
+export const MODERATION = { windowSeconds: 3_600, max: 30 } as const;
+export const HEAVY = { windowSeconds: 3_600, max: 30 } as const;
+export const READ = { windowSeconds: 60, max: 600, keyBy: "ip" } as const;
+export const SEARCH = { windowSeconds: 60, max: 30, keyBy: "ip" } as const;

--- a/api/src/routes/graph.ts
+++ b/api/src/routes/graph.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { CONTRIBUTION } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import {
   createPrerequisiteSchema,
@@ -17,6 +19,7 @@ export const prerequisitesRouter = new Hono<HonoEnv>()
   .post(
     "/",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "prerequisite-create" }),
     zValidator("json", createPrerequisiteSchema),
     async (c) => {
       const { from_guide_base_id, to_guide_base_id } = c.req.valid("json");
@@ -30,13 +33,18 @@ export const prerequisitesRouter = new Hono<HonoEnv>()
   )
 
   // Suspends the edge; returns { edge }. 404 if missing.
-  .delete("/:id", requireUser, async (c) => {
-    const edge = await suspendPrerequisite(
-      c.get("supabase"),
-      c.req.param("id")
-    );
-    return c.json({ edge }, 200);
-  });
+  .delete(
+    "/:id",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "prerequisite-suspend" }),
+    async (c) => {
+      const edge = await suspendPrerequisite(
+        c.get("supabase"),
+        c.req.param("id")
+      );
+      return c.json({ edge }, 200);
+    }
+  );
 
 export const todosRouter = new Hono<HonoEnv>()
   // Returns open todo prerequisites as { todos }.
@@ -49,6 +57,7 @@ export const todosRouter = new Hono<HonoEnv>()
   .post(
     "/",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "todo-create" }),
     zValidator("json", createTodoPrerequisiteSchema),
     async (c) => {
       const { guide_base_id, title } = c.req.valid("json");

--- a/api/src/routes/guides.ts
+++ b/api/src/routes/guides.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { requireUser } from "../middleware/auth.middleware";
 import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { CONTRIBUTION, CREATE, MODERATION } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import { zValidator } from "@hono/zod-validator";
 import {
@@ -59,12 +60,11 @@ export const guidesRouter = new Hono<HonoEnv>()
     return c.json({ guides });
   })
 
-  // 201 with { revision_id } for the editor route. Rate-limited to 15
-  // guide creations per 24h per user to prevent spam.
+  // 201 with { revision_id } for the editor route.
   .post(
     "/",
     requireUser,
-    rateLimitMiddleware({ windowSeconds: 86_400, max: 15 }),
+    rateLimitMiddleware({ ...CREATE, bucket: "guide-create" }),
     zValidator("json", createGuideBody),
     async (c) => {
       const { revision_id } = await createGuide(
@@ -86,15 +86,20 @@ export const guidesRouter = new Hono<HonoEnv>()
   })
 
   // Archives the guide. 404 if missing or not permitted.
-  .delete("/:slug", requireUser, async (c) => {
-    const guide = await archiveGuide(c.get("supabase"), c.req.param("slug"));
-    // Drop the archived guide from the search index (best-effort).
-    scheduleSearchSync(
-      c,
-      syncGuideDocument(c.env, c.get("supabase"), guide.id)
-    );
-    return c.json({ guide });
-  })
+  .delete(
+    "/:slug",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "guide-archive" }),
+    async (c) => {
+      const guide = await archiveGuide(c.get("supabase"), c.req.param("slug"));
+      // Drop the archived guide from the search index (best-effort).
+      scheduleSearchSync(
+        c,
+        syncGuideDocument(c.env, c.get("supabase"), guide.id)
+      );
+      return c.json({ guide });
+    }
+  )
 
   // Returns the transitive prerequisite graph as { nodes, edges }.
   .get("/:slug/walkthrough", async (c) => {
@@ -118,6 +123,7 @@ export const guidesRouter = new Hono<HonoEnv>()
   .post(
     "/:slug/variants",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "variant-create" }),
     zValidator("json", createVariantBody),
     async (c) => {
       const { revision_id } = await addGuideVariant(
@@ -147,15 +153,24 @@ export const variantsRouter = new Hono<HonoEnv>()
   })
 
   // Archives the variant. 404 if missing or not permitted.
-  .delete("/:id", requireUser, async (c) => {
-    const variant = await archiveVariant(c.get("supabase"), c.req.param("id"));
-    return c.json({ variant });
-  })
+  .delete(
+    "/:id",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "variant-archive" }),
+    async (c) => {
+      const variant = await archiveVariant(
+        c.get("supabase"),
+        c.req.param("id")
+      );
+      return c.json({ variant });
+    }
+  )
 
   // Stores the caller's vote; returns { vote }.
   .put(
     "/:id/vote",
     requireUser,
+    rateLimitMiddleware({ ...MODERATION, bucket: "vote-cast" }),
     zValidator("json", castVoteSchema),
     async (c) => {
       const { vote } = await castVote(
@@ -169,10 +184,15 @@ export const variantsRouter = new Hono<HonoEnv>()
   )
 
   // 204 once the caller's vote is gone.
-  .delete("/:id/vote", requireUser, async (c) => {
-    await retractVote(c.get("supabase"), c.get("user").id, c.req.param("id"));
-    return c.body(null, 204);
-  })
+  .delete(
+    "/:id/vote",
+    requireUser,
+    rateLimitMiddleware({ ...MODERATION, bucket: "vote-retract" }),
+    async (c) => {
+      await retractVote(c.get("supabase"), c.get("user").id, c.req.param("id"));
+      return c.body(null, 204);
+    }
+  )
 
   // Returns the published versions as { revisions }, newest live first.
   .get("/:id/revisions", async (c) => {
@@ -184,19 +204,25 @@ export const variantsRouter = new Hono<HonoEnv>()
   })
 
   // 201 with { revision_id } for the editor route.
-  .post("/:id/revisions", requireUser, async (c) => {
-    const { revision_id } = await createVariantRevision(
-      c.get("supabase"),
-      c.get("user").id,
-      c.req.param("id")
-    );
-    return c.json({ revision_id }, 201);
-  })
+  .post(
+    "/:id/revisions",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "variant-revision-create" }),
+    async (c) => {
+      const { revision_id } = await createVariantRevision(
+        c.get("supabase"),
+        c.get("user").id,
+        c.req.param("id")
+      );
+      return c.json({ revision_id }, 201);
+    }
+  )
 
   // 201 with { revision_id } for the restored snapshot's new revision.
   .post(
     "/:id/rollback",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "variant-rollback" }),
     zValidator("json", rollbackRevisionSchema),
     async (c) => {
       const { revision_id } = await rollbackVariant(
@@ -223,6 +249,7 @@ export const guideRevisionsRouter = new Hono<HonoEnv>()
   .patch(
     "/:id",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "guide-revision-update" }),
     zValidator("json", updateRevisionSchema),
     async (c) => {
       const { revision, subjects } = await updateRevision(
@@ -236,13 +263,18 @@ export const guideRevisionsRouter = new Hono<HonoEnv>()
   )
 
   // 201 with { review_case_id } once the revision is submitted and its case opened.
-  .post("/:id/submit", requireUser, async (c) => {
-    const { review_case_id } = await submitRevision(
-      c.get("supabase"),
-      c.req.param("id")
-    );
-    return c.json({ review_case_id }, 201);
-  })
+  .post(
+    "/:id/submit",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "guide-revision-submit" }),
+    async (c) => {
+      const { review_case_id } = await submitRevision(
+        c.get("supabase"),
+        c.req.param("id")
+      );
+      return c.json({ review_case_id }, 201);
+    }
+  )
 
   // Returns the diff against the previous approved revision as { from, to, fields }.
   .get("/:id/diff/prev", async (c) => {

--- a/api/src/routes/identity.ts
+++ b/api/src/routes/identity.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { updateProfileSchema } from "@bluelearn/schemas";
 import { getServiceSupabase, requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { CONTRIBUTION } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import {
   getMyDrafts,
@@ -32,6 +34,7 @@ export const meRouter = new Hono<HonoEnv>()
   .patch(
     "/",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "profile-update" }),
     zValidator("json", updateProfileSchema),
     async (c) => {
       const { profile, roles } = await updateMyProfile(

--- a/api/src/routes/media.ts
+++ b/api/src/routes/media.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { HEAVY } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import { mediaUploadSchema } from "@bluelearn/schemas";
 
@@ -12,6 +14,7 @@ export const mediaRouter = new Hono<HonoEnv>()
   .post(
     "/upload",
     requireUser,
+    rateLimitMiddleware({ ...HEAVY, bucket: "media-upload" }),
     zValidator("form", mediaUploadSchema),
     async (c) => {
       const { file, revision_id } = c.req.valid("form");

--- a/api/src/routes/objectives.ts
+++ b/api/src/routes/objectives.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 import { requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { CONTRIBUTION, CREATE } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import { zValidator } from "@hono/zod-validator";
 import {
@@ -40,6 +42,7 @@ export const objectivesRouter = new Hono<HonoEnv>()
   .post(
     "/",
     requireUser,
+    rateLimitMiddleware({ ...CREATE, bucket: "objective-create" }),
     zValidator("json", createObjectiveSchema),
     async (c) => {
       const { revision_id } = await createObjective(
@@ -60,18 +63,23 @@ export const objectivesRouter = new Hono<HonoEnv>()
   })
 
   // Archives the objective. 404 if missing or not permitted.
-  .delete("/:slug", requireUser, async (c) => {
-    const objective = await archiveObjective(
-      c.get("supabase"),
-      c.req.param("slug")
-    );
-    // Drop the archived objective from the search index (best-effort).
-    scheduleSearchSync(
-      c,
-      syncObjectiveDocument(c.env, c.get("supabase"), objective.id)
-    );
-    return c.json({ objective });
-  })
+  .delete(
+    "/:slug",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "objective-archive" }),
+    async (c) => {
+      const objective = await archiveObjective(
+        c.get("supabase"),
+        c.req.param("slug")
+      );
+      // Drop the archived objective from the search index (best-effort).
+      scheduleSearchSync(
+        c,
+        syncObjectiveDocument(c.env, c.get("supabase"), objective.id)
+      );
+      return c.json({ objective });
+    }
+  )
 
   // Returns the revision history as { revisions }, newest first.
   .get("/:slug/revisions", async (c) => {
@@ -101,6 +109,10 @@ export const objectiveRevisionsRouter = new Hono<HonoEnv>()
   .patch(
     "/:id",
     requireUser,
+    rateLimitMiddleware({
+      ...CONTRIBUTION,
+      bucket: "objective-revision-update",
+    }),
     zValidator("json", updateObjectiveRevisionSchema),
     async (c) => {
       const { revision, subjects } = await updateObjectiveRevision(
@@ -128,6 +140,7 @@ export const objectiveRevisionsRouter = new Hono<HonoEnv>()
   .patch(
     "/:id/nodes/:baseId",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "objective-node-update" }),
     zValidator("json", updateObjectiveNodeSchema),
     async (c) => {
       const { node } = await updateObjectiveNode(
@@ -141,23 +154,29 @@ export const objectiveRevisionsRouter = new Hono<HonoEnv>()
   )
 
   // Publishes the draft. Returns { slug }; 403 unless the author/curator.
-  .post("/:id/publish", requireUser, async (c) => {
-    const { slug } = await publishObjectiveRevision(
-      c.get("supabase"),
-      c.req.param("id")
-    );
-    // The objective just went (or stayed) live — refresh its search document.
-    scheduleSearchSync(
-      c,
-      syncObjectiveForRevision(c.env, c.get("supabase"), c.req.param("id"))
-    );
-    return c.json({ slug });
-  })
+  .post(
+    "/:id/publish",
+    requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "objective-publish" }),
+    async (c) => {
+      const { slug } = await publishObjectiveRevision(
+        c.get("supabase"),
+        c.req.param("id")
+      );
+      // The objective just went (or stayed) live — refresh its search document.
+      scheduleSearchSync(
+        c,
+        syncObjectiveForRevision(c.env, c.get("supabase"), c.req.param("id"))
+      );
+      return c.json({ slug });
+    }
+  )
 
   // 201 with { revision_id } for a new draft cloned from the body's revision_id.
   .post(
     "/:id/rollback",
     requireUser,
+    rateLimitMiddleware({ ...CONTRIBUTION, bucket: "objective-rollback" }),
     zValidator("json", rollbackRevisionSchema),
     async (c) => {
       const { revision_id } = await rollbackObjectiveRevision(

--- a/api/src/routes/reviews.ts
+++ b/api/src/routes/reviews.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { createDecisionSchema } from "@bluelearn/schemas";
 import { requireUser } from "../middleware/auth.middleware";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { MODERATION } from "../middleware/rateLimits";
 import type { HonoEnv } from "../types";
 import {
   castDecision,
@@ -37,6 +39,7 @@ export const reviewsRouter = new Hono<HonoEnv>()
   .post(
     "/cases/:id/decisions",
     requireUser,
+    rateLimitMiddleware({ ...MODERATION, bucket: "review-decision" }),
     zValidator("json", createDecisionSchema),
     async (c) => {
       const input = c.req.valid("json");

--- a/api/src/routes/search.ts
+++ b/api/src/routes/search.ts
@@ -2,13 +2,20 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { searchQuerySchema } from "@bluelearn/schemas";
 import type { HonoEnv } from "../types";
+import { rateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { SEARCH } from "../middleware/rateLimits";
 import { searchCollections } from "../services/search.service";
 
 export const searchRouter = new Hono<HonoEnv>()
   // Full-text search, keyed by collection (default guides and objectives).
   // Supports filter_by / sort_by / facet_by passed straight through to
   // Typesense.
-  .get("/", zValidator("query", searchQuerySchema), async (c) => {
-    const results = await searchCollections(c.env, c.req.valid("query"));
-    return c.json({ results }, 200);
-  });
+  .get(
+    "/",
+    rateLimitMiddleware({ ...SEARCH, bucket: "search" }),
+    zValidator("query", searchQuerySchema),
+    async (c) => {
+      const results = await searchCollections(c.env, c.req.valid("query"));
+      return c.json({ results }, 200);
+    }
+  );

--- a/api/tests/helpers.ts
+++ b/api/tests/helpers.ts
@@ -78,18 +78,35 @@ export async function makeUser(): Promise<{ token: string; userId: string }> {
   return { token: session.session.access_token, userId: created.user.id };
 }
 
-// Shorthand for the Authorization header bundle most requests need.
-export function auth(token: string) {
-  return { headers: { Authorization: `Bearer ${token}` } };
+export function clientIp(): string {
+  const octet = () => Math.floor(Math.random() * 256);
+  return `${octet()}.${octet()}.${octet()}.${octet()}`;
+}
+
+// Shorthand for the Authorization header bundle most requests need. Pass an
+// ip to pin the request to its own rate-limit bucket.
+export function auth(token: string, ip?: string) {
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(ip ? { "CF-Connecting-IP": ip } : {}),
+    },
+  };
 }
 
 // Shorthand for an authorized JSON request init.
-export function jsonAuth(token: string, method: string, body: unknown) {
+export function jsonAuth(
+  token: string,
+  method: string,
+  body: unknown,
+  ip?: string
+) {
   return {
     method,
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
+      ...(ip ? { "CF-Connecting-IP": ip } : {}),
     },
     body: JSON.stringify(body),
   };

--- a/api/tests/rate-limit.test.ts
+++ b/api/tests/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import app from "../src/index";
-import { env, jsonAuth, makeUser } from "./helpers";
+import { clientIp, env, jsonAuth, makeUser } from "./helpers";
 import { expectToMatchSpec } from "./openapi";
 
 function guideBody() {
@@ -11,39 +11,32 @@ function guideBody() {
   };
 }
 
-describe("POST /guides rate limit", () => {
-  it("allows up to 15 guide creations per user per day", async () => {
-    const { token } = await makeUser();
+async function createGuide(token: string, ip: string) {
+  return app.request("/guides", jsonAuth(token, "POST", guideBody(), ip), env);
+}
 
-    for (let i = 0; i < 15; i++) {
-      const res = await app.request(
-        "/guides",
-        jsonAuth(token, "POST", guideBody()),
-        env
-      );
-      expect(res.status).toBe(201);
+describe("POST /guides rate limit (CREATE tier)", () => {
+  it("allows up to 20 guide creations per user per day", async () => {
+    const { token } = await makeUser();
+    const ip = clientIp();
+
+    for (let i = 0; i < 20; i++) {
+      expect((await createGuide(token, ip)).status).toBe(201);
     }
   });
 
-  it("returns 429 on the 16th guide creation within the same day", async () => {
+  it("returns 429 on the 21st guide creation within the same day", async () => {
     const { token } = await makeUser();
+    const ip = clientIp();
 
-    for (let i = 0; i < 15; i++) {
-      await app.request("/guides", jsonAuth(token, "POST", guideBody()), env);
-    }
+    for (let i = 0; i < 20; i++) await createGuide(token, ip);
 
-    const res = await app.request(
-      "/guides",
-      jsonAuth(token, "POST", guideBody()),
-      env
-    );
+    const res = await createGuide(token, ip);
 
     expect(res.status).toBe(429);
     await expectToMatchSpec(res, "POST", "/guides");
-    expect(res.headers.get("Retry-After")).not.toBeNull();
     const retryAfter = Number(res.headers.get("Retry-After"));
     expect(retryAfter).toBeGreaterThan(0);
-
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Rate limit exceeded");
   });
@@ -52,25 +45,84 @@ describe("POST /guides rate limit", () => {
     const first = await makeUser();
     const second = await makeUser();
 
-    for (let i = 0; i < 15; i++) {
-      await app.request(
-        "/guides",
-        jsonAuth(first.token, "POST", guideBody()),
-        env
-      );
-    }
+    for (let i = 0; i < 20; i++) await createGuide(first.token, clientIp());
 
-    const res = await app.request(
-      "/guides",
-      jsonAuth(second.token, "POST", guideBody()),
-      env
-    );
-
-    expect(res.status).toBe(201);
+    expect((await createGuide(second.token, clientIp())).status).toBe(201);
   });
 
   it("returns 401 (not 429) for unauthenticated requests", async () => {
     const res = await app.request("/guides", { method: "POST" }, env);
     expect(res.status).toBe(401);
+  });
+});
+
+describe("per-route bucket isolation", () => {
+  it("exhausting one route does not spend another route's budget", async () => {
+    const { token } = await makeUser();
+    const ip = clientIp();
+
+    for (let i = 0; i < 20; i++) await createGuide(token, ip);
+    expect((await createGuide(token, ip)).status).toBe(429);
+
+    // Same user, different bucket -- its counter is untouched.
+    const res = await app.request(
+      "/me",
+      jsonAuth(token, "PATCH", { display_name: "Tony" }, ip),
+      env
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("global read ceiling (READ tier, keyed by IP)", () => {
+  it("caps unauthenticated reads per IP and 429s past the limit", async () => {
+    const ip = clientIp();
+
+    for (let i = 0; i < 600; i++) {
+      const res = await app.request(
+        "/",
+        { headers: { "CF-Connecting-IP": ip } },
+        env
+      );
+      expect(res.status).toBe(200);
+    }
+
+    const res = await app.request(
+      "/",
+      { headers: { "CF-Connecting-IP": ip } },
+      env
+    );
+    expect(res.status).toBe(429);
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThan(0);
+  });
+
+  it("does not share the ceiling between IPs", async () => {
+    const res = await app.request(
+      "/",
+      { headers: { "CF-Connecting-IP": clientIp() } },
+      env
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("search rate limit (SEARCH tier, keyed by IP)", () => {
+  it("429s past 30 searches per IP regardless of the search backend", async () => {
+    const ip = clientIp();
+
+    for (let i = 0; i < 30; i++) {
+      await app.request(
+        "/search?q=test",
+        { headers: { "CF-Connecting-IP": ip } },
+        env
+      );
+    }
+
+    const res = await app.request(
+      "/search?q=test",
+      { headers: { "CF-Connecting-IP": ip } },
+      env
+    );
+    expect(res.status).toBe(429);
   });
 });


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Applies rate limiting to every write route and to public reads. Previously `rateLimitMiddleware` existed but was mounted only on `POST /guides`.

Closes #182.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
