### PR TITLE
feat(app) Add show password toggle in password fields

### DIFF
--- a/app/src/components/forms/LoginForm.tsx
+++ b/app/src/components/forms/LoginForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { signIn } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ export function LoginForm({
 }: React.ComponentProps<"div">) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -102,15 +104,31 @@ export function LoginForm({
                       </Link>
                     </div>
 
-                    <Input
-                      id="password"
-                      type="password"
-                      autoComplete="current-password"
-                      className="h-10 rounded-md"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
+                    <div className="relative w-full">
+                      <Input
+                        id="password"
+                        type={showPassword ? "text" : "password"}
+                        autoComplete="current-password"
+                        className="h-10 rounded-md pr-10"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        aria-label={
+                          showPassword ? "Hide password" : "Show password"
+                        }
+                        className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                      >
+                        {showPassword ? (
+                          <EyeOff size={20} />
+                        ) : (
+                          <Eye size={20} />
+                        )}
+                      </button>
+                    </div>
                   </Field>
                 </FieldGroup>
               </div>

--- a/app/src/components/forms/RegisterForm.tsx
+++ b/app/src/components/forms/RegisterForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { signUp } from "@/lib/auth";
 import { validateRegister } from "@/lib/authValidation";
@@ -31,7 +32,9 @@ export function RegisterForm({
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [acceptedPolicies, setAcceptedPolicies] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -131,15 +134,31 @@ export function RegisterForm({
                         Password
                       </FieldLabel>
 
-                      <Input
-                        id="password"
-                        type="password"
-                        autoComplete="new-password"
-                        className="h-10 rounded-md"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        required
-                      />
+                      <div className="relative w-full">
+                        <Input
+                          id="password"
+                          type={showPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          className="h-10 rounded-md pr-10"
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          required
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowPassword((prev) => !prev)}
+                          aria-label={
+                            showPassword ? "Hide password" : "Show password"
+                          }
+                          className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                        >
+                          {showPassword ? (
+                            <EyeOff size={20} />
+                          ) : (
+                            <Eye size={20} />
+                          )}
+                        </button>
+                      </div>
                     </Field>
 
                     <Field className="space-y-2">
@@ -147,15 +166,35 @@ export function RegisterForm({
                         Confirm Password
                       </FieldLabel>
 
-                      <Input
-                        id="confirm-password"
-                        type="password"
-                        autoComplete="new-password"
-                        className="h-10 rounded-md"
-                        value={confirmPassword}
-                        onChange={(e) => setConfirmPassword(e.target.value)}
-                        required
-                      />
+                      <div className="relative w-full">
+                        <Input
+                          id="confirm-password"
+                          type={showConfirmPassword ? "text" : "password"}
+                          autoComplete="new-password"
+                          className="h-10 rounded-md pr-10"
+                          value={confirmPassword}
+                          onChange={(e) => setConfirmPassword(e.target.value)}
+                          required
+                        />
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setShowConfirmPassword((prev) => !prev)
+                          }
+                          aria-label={
+                            showConfirmPassword
+                              ? "Hide confirm password"
+                              : "Show confirm password"
+                          }
+                          className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                        >
+                          {showConfirmPassword ? (
+                            <EyeOff size={20} />
+                          ) : (
+                            <Eye size={20} />
+                          )}
+                        </button>
+                      </div>
                     </Field>
                   </div>
 

--- a/app/src/components/forms/ResetPasswordForm.tsx
+++ b/app/src/components/forms/ResetPasswordForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { updatePassword } from "@/lib/auth";
 import { MIN_PASSWORD_LENGTH } from "@/lib/authValidation";
@@ -28,6 +29,9 @@ export function ResetPasswordForm({
 }: React.ComponentProps<"div">) {
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   const [confirmPassword, setConfirmPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -84,15 +88,27 @@ export function ResetPasswordForm({
                   New password
                 </FieldLabel>
 
-                <Input
-                  id="password"
-                  type="password"
-                  autoComplete="new-password"
-                  className="h-10 rounded-md"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                />
+                <div className="relative w-full">
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    className="h-10 rounded-md"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    aria-label={
+                      showPassword ? "Hide password" : "Show password"
+                    }
+                    className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                  >
+                    {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                  </button>
+                </div>
               </Field>
 
               <Field className="space-y-2">
@@ -100,15 +116,33 @@ export function ResetPasswordForm({
                   Confirm new password
                 </FieldLabel>
 
-                <Input
-                  id="confirm-password"
-                  type="password"
-                  autoComplete="new-password"
-                  className="h-10 rounded-md"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  required
-                />
+                <div className="relative w-full">
+                  <Input
+                    id="confirm-password"
+                    type={showConfirmPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    className="h-10 rounded-md"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    aria-label={
+                      showConfirmPassword
+                        ? "Hide confirm password"
+                        : "Show confirm password"
+                    }
+                    className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff size={20} />
+                    ) : (
+                      <Eye size={20} />
+                    )}
+                  </button>
+                </div>
               </Field>
 
               <FieldDescription className="text-xs text-muted-foreground">

--- a/app/src/routes/settings.account.tsx
+++ b/app/src/routes/settings.account.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { Eye, EyeOff } from "lucide-react";
 import { signIn, signOut, updateEmail, updatePassword } from "@/lib/auth";
 import { MIN_PASSWORD_LENGTH } from "@/lib/authValidation";
 import { deleteMyAccount, getMyIdentity } from "@/lib/api/identity";
@@ -38,6 +39,9 @@ function RouteComponent() {
     new: "",
     confirmNew: "",
   });
+  const [showOldPassword, setShowOldPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
 
   const [saving, setSaving] = useState(false);
   const [updating, setUpdating] = useState(false);
@@ -217,21 +221,39 @@ function RouteComponent() {
                   >
                     Old Password
                   </FieldLabel>
-                  <Input
-                    autoFocus
-                    id="old-password"
-                    name="current-password"
-                    type="password"
-                    autoComplete="current-password"
-                    className="h-10 rounded-md"
-                    value={password.old}
-                    onChange={(e) => {
-                      setPassword({
-                        ...password,
-                        old: e.target.value,
-                      });
-                    }}
-                  />
+                  <div className="relative w-full">
+                    <Input
+                      autoFocus
+                      id="old-password"
+                      name="current-password"
+                      type={showOldPassword ? "text" : "password"}
+                      autoComplete="current-password"
+                      className="h-10 rounded-md pr-10"
+                      value={password.old}
+                      onChange={(e) => {
+                        setPassword({
+                          ...password,
+                          old: e.target.value,
+                        });
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowOldPassword((prev) => !prev)}
+                      aria-label={
+                        showOldPassword
+                          ? "Hide old password"
+                          : "Show old password"
+                      }
+                      className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                    >
+                      {showOldPassword ? (
+                        <EyeOff size={20} />
+                      ) : (
+                        <Eye size={20} />
+                      )}
+                    </button>
+                  </div>
                 </div>
 
                 <div className="space-y-2">
@@ -241,20 +263,38 @@ function RouteComponent() {
                   >
                     New Password
                   </FieldLabel>
-                  <Input
-                    id="new-password"
-                    name="new-password"
-                    type="password"
-                    autoComplete="new-password"
-                    className="h-10 rounded-md"
-                    value={password.new}
-                    onChange={(e) => {
-                      setPassword({
-                        ...password,
-                        new: e.target.value,
-                      });
-                    }}
-                  />
+                  <div className="relative w-full">
+                    <Input
+                      id="new-password"
+                      name="new-password"
+                      type={showNewPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      className="h-10 rounded-md pr-10"
+                      value={password.new}
+                      onChange={(e) => {
+                        setPassword({
+                          ...password,
+                          new: e.target.value,
+                        });
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowNewPassword((prev) => !prev)}
+                      aria-label={
+                        showNewPassword
+                          ? "Hide new password"
+                          : "Show new password"
+                      }
+                      className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                    >
+                      {showNewPassword ? (
+                        <EyeOff size={20} />
+                      ) : (
+                        <Eye size={20} />
+                      )}
+                    </button>
+                  </div>
                 </div>
 
                 <div className="space-y-2">
@@ -264,20 +304,38 @@ function RouteComponent() {
                   >
                     Confirm New Password
                   </FieldLabel>
-                  <Input
-                    id="confirm-password"
-                    name="confirm-password"
-                    type="password"
-                    autoComplete="new-password"
-                    className="h-10 rounded-md"
-                    value={password.confirmNew}
-                    onChange={(e) => {
-                      setPassword({
-                        ...password,
-                        confirmNew: e.target.value,
-                      });
-                    }}
-                  />
+                  <div className="relative w-full">
+                    <Input
+                      id="confirm-password"
+                      name="confirm-password"
+                      type={showConfirmNewPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      className="h-10 rounded-md pr-10"
+                      value={password.confirmNew}
+                      onChange={(e) => {
+                        setPassword({
+                          ...password,
+                          confirmNew: e.target.value,
+                        });
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirmNewPassword((prev) => !prev)}
+                      aria-label={
+                        showConfirmNewPassword
+                          ? "Hide confirm new password"
+                          : "Show confirm new password"
+                      }
+                      className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+                    >
+                      {showConfirmNewPassword ? (
+                        <EyeOff size={20} />
+                      ) : (
+                        <Eye size={20} />
+                      )}
+                    </button>
+                  </div>
                 </div>
 
                 <div className="flex items-center justify-end gap-2 pt-1">


### PR DESCRIPTION
## Summary

Password fields in LoginForm, RegisterForm, ResetPasswordForm, and change password section of the account settings now contain a button to toggle showing the password:

<img width="291" height="382" alt="Screenshot 2026-08-01 141234" src="https://github.com/user-attachments/assets/93464631-2abd-4d09-9aaf-afcb77c4007e" />
<img width="235" height="263" alt="Screenshot 2026-08-01 141201" src="https://github.com/user-attachments/assets/77f0ba2e-3afd-4e4c-ae52-845f190160f5" />
<img width="671" height="375" alt="Screenshot 2026-08-01 141128" src="https://github.com/user-attachments/assets/fff41a8c-8865-4cb2-9ea7-3485dc8815c8" />
<img width="246" height="285" alt="Screenshot 2026-08-01 141038" src="https://github.com/user-attachments/assets/c8e5ed9d-2510-4bc8-85ef-152244c4d600" />

( Closes #219 )

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [X] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
