### PR TITLE
feat: render prerequisites on guide sidebar

### DIFF
--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -4,6 +4,7 @@ import type {
   CreateVariantInput,
   Guide,
   GuideListItem,
+  GuideReference,
   Pagination,
   SubjectReference,
   Walkthrough,
@@ -236,8 +237,40 @@ export async function createGuide(
   return { revision_id };
 }
 
-// Resolve a guide by slug to its canonical content + subject tags.
-// The prereq/dependent neighborhood is deferred to the graph pass.
+// A base's direct prerequisites.
+async function loadPrerequisites(
+  supabase: DB,
+  baseId: string
+): Promise<GuideReference[]> {
+  const { data, error } = await supabase
+    .from("guide_edges")
+    .select(
+      `from:guide_bases!from_guide_base_id(
+         slug,
+         canonical:guides!guide_bases_canonical_guide_id_fkey(
+           current:guide_revisions!guides_current_revision_id_fkey(title)
+         )
+       )`
+    )
+    .eq("to_guide_base_id", baseId)
+    .eq("edge_type", "prerequisite")
+    .eq("is_suspended", false);
+
+  if (error) {
+    console.error(error);
+    throw new ServiceError("Failed to load prerequisites", 500);
+  }
+
+  return (data ?? [])
+    .map((edge) => edge.from)
+    .filter((base) => base != null)
+    .map((base) => ({
+      slug: base.slug ?? "",
+      title: base.canonical?.current?.title ?? base.slug ?? "",
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+}
+
 export async function getGuideBySlug(supabase: DB, rawSlug: string) {
   const slug = rawSlug.toLowerCase();
 
@@ -257,7 +290,10 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
 
   const canonical = guide.canonical;
   const current = canonical?.current ?? null;
-  const subjects = await loadCanonicalTags(supabase, current?.id ?? null);
+  const [subjects, prerequisites] = await Promise.all([
+    loadCanonicalTags(supabase, current?.id ?? null),
+    loadPrerequisites(supabase, guide.id),
+  ]);
   const authorId = canonical?.author_id ?? null;
   const usernames = await loadUsernames(supabase, [authorId]);
 
@@ -272,7 +308,7 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
     duration_minutes: readingMinutes(current?.word_count ?? 0),
     created_at: guide.created_at,
     tags: subjects.map((s) => ({ slug: s.slug, name: s.name })),
-    prerequisites: [],
+    prerequisites,
   };
 
   return detail;

--- a/app/src/components/sidebar/GuideSidebar.tsx
+++ b/app/src/components/sidebar/GuideSidebar.tsx
@@ -28,37 +28,6 @@ export const GuideSidebar = ({
     <aside className="h-[calc(100vh-70px)] overflow-y-auto border-r px-6 py-6">
       {sidebarActions}
 
-      {/* Prerequisites */}
-      {showPrerequisites && (
-        <CollapsibleSection title={<p className="ml-auto">Prerequisites</p>}>
-          <ul className="space-y-2">
-            {guide.prerequisites.map((prereq: GuideReference) => (
-              <li
-                key={prereq.slug}
-                className="text-sm text-muted-foreground hover:text-foreground"
-                style={{
-                  paddingLeft: 6,
-                }}
-              >
-                <Link
-                  to="/guides/$slug"
-                  params={{ slug: prereq.slug }}
-                  state={{
-                    breadcrumbOrigin: {
-                      type: "guide",
-                      title: guide.title,
-                      path: `/guides/${slug}`,
-                    },
-                  }}
-                >
-                  {prereq.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </CollapsibleSection>
-      )}
-
       {/* TOC */}
       <CollapsibleSection
         title={<p className="ml-auto">Table of Contents</p>}
@@ -68,7 +37,7 @@ export const GuideSidebar = ({
           {headings.map((h, idx) => (
             <li
               key={idx}
-              className="cursor-pointer text-sm text-muted-foreground hover:text-foreground"
+              className="cursor-pointer text-xs text-muted-foreground hover:text-foreground"
               style={{
                 paddingLeft:
                   h.level === 1
@@ -85,6 +54,47 @@ export const GuideSidebar = ({
           ))}
         </ul>
       </CollapsibleSection>
+
+      {/* Prerequisites */}
+      {showPrerequisites && (
+        <CollapsibleSection
+          defaultOpen={true}
+          title={<p className="ml-auto">Prerequisites</p>}
+        >
+          {guide.prerequisites.length === 0 ? (
+            <p
+              className="text-xs text-muted-foreground"
+              style={{ paddingLeft: 12 }}
+            >
+              None declared
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {guide.prerequisites.map((prereq: GuideReference) => (
+                <li
+                  key={prereq.slug}
+                  className="cursor-pointer text-xs text-muted-foreground hover:text-foreground"
+                  style={{ paddingLeft: 12 }}
+                >
+                  <Link
+                    to="/guides/$slug"
+                    params={{ slug: prereq.slug }}
+                    state={{
+                      breadcrumbOrigin: {
+                        type: "guide",
+                        title: guide.title,
+                        path: `/guides/${slug}`,
+                      },
+                    }}
+                  >
+                    {prereq.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CollapsibleSection>
+      )}
 
       {reviewSection}
     </aside>

--- a/app/src/components/sidebar/ReviewSidebar.tsx
+++ b/app/src/components/sidebar/ReviewSidebar.tsx
@@ -469,7 +469,7 @@ export const ReviewSidebar = ({
                 count={
                   revisionData.prerequisites.length + revisionData.todos.length
                 }
-                empty="None declared."
+                empty="None declared"
               >
                 {revisionData.prerequisites.map(
                   (p: { slug: string; title?: string }) => (


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Render direct prerequisites for a particular guide in the sidebar.

Closes #252.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
