### PR TITLE
fix: make sidebars sticky

### DIFF
--- a/app/src/components/sidebar/GuideSidebar.tsx
+++ b/app/src/components/sidebar/GuideSidebar.tsx
@@ -25,7 +25,7 @@ export const GuideSidebar = ({
   );
 
   return (
-    <aside className="hidden px-6 py-6 md:block md:h-[calc(100vh-70px)] md:overflow-y-auto md:border-r">
+    <aside className="hidden px-6 py-6 md:sticky md:top-[65px] md:block md:h-[calc(100vh-65px)] md:self-start md:overflow-y-auto md:border-r">
       {sidebarActions}
 
       {/* TOC */}

--- a/app/src/components/sidebar/SettingsSidebar.tsx
+++ b/app/src/components/sidebar/SettingsSidebar.tsx
@@ -27,7 +27,7 @@ export const SettingsSidebar = () => {
   });
 
   return (
-    <aside className="fixed top-[65px] hidden h-[calc(100vh-65px)] w-64 shrink-0 overflow-y-auto px-6 py-6 md:block">
+    <aside className="sticky top-[65px] hidden max-h-[calc(100vh-65px)] w-64 shrink-0 self-start overflow-y-auto px-6 py-6 md:block">
       <div className="mb-6">
         <h2 className="font-mono text-[12px] tracking-[0.08em] text-muted-foreground uppercase">
           Settings

--- a/app/src/components/sidebar/SettingsSidebar.tsx
+++ b/app/src/components/sidebar/SettingsSidebar.tsx
@@ -27,7 +27,7 @@ export const SettingsSidebar = () => {
   });
 
   return (
-    <aside className="fixed top-[70px] hidden h-[calc(100vh-70px)] w-64 shrink-0 overflow-y-auto px-6 py-6 md:block">
+    <aside className="fixed top-[65px] hidden h-[calc(100vh-65px)] w-64 shrink-0 overflow-y-auto px-6 py-6 md:block">
       <div className="mb-6">
         <h2 className="font-mono text-[12px] tracking-[0.08em] text-muted-foreground uppercase">
           Settings

--- a/app/src/components/sidebar/SubjectSidebar.tsx
+++ b/app/src/components/sidebar/SubjectSidebar.tsx
@@ -12,7 +12,7 @@ type SubjectsProps = {
 
 export const SubjectSidebar = ({ groups }: SubjectsProps) => {
   return (
-    <aside className="hidden overflow-y-auto border-r px-6 md:block">
+    <aside className="hidden border-r px-6 md:sticky md:top-[65px] md:block md:h-[calc(100vh-65px)] md:self-start md:overflow-y-auto">
       {groups.map(({ char, subjects }) => (
         <CollapsibleSection key={char} title={char} defaultOpen>
           <ul className="space-y-2">

--- a/app/src/routes/guides/$slug/walkthrough.tsx
+++ b/app/src/routes/guides/$slug/walkthrough.tsx
@@ -65,7 +65,7 @@ function RouteComponent() {
     walkthroughData?.nodes.find((node) => node.slug === slug)?.title ?? "";
 
   return (
-    <div className="mx-auto max-w-7xl bg-background md:h-[calc(100vh-70px)]">
+    <div className="mx-auto max-w-7xl bg-background md:h-[calc(100vh-65px)]">
       {/* Panel sits under the graph on small screens, beside it from md up. */}
       <section className="flex h-full flex-col-reverse md:grid md:grid-cols-[320px_1fr]">
         {selectedNode ? (

--- a/app/src/routes/settings.tsx
+++ b/app/src/routes/settings.tsx
@@ -14,10 +14,9 @@ export const Route = createFileRoute("/settings")({
 function RouteComponent() {
   return (
     <div className="mx-auto max-w-[1280px] bg-background">
-      <div className="flex min-h-[calc(100svh_-_64px)]">
+      <div className="flex min-h-[calc(100svh_-_65px)]">
         {/* Left Sidebar Navigation */}
         <SettingsSidebar />
-        <div className="hidden w-64 shrink-0 md:block" />
 
         {/* Right Content Area */}
         <div className="min-w-0 flex-1 px-4 py-8 sm:px-8 md:border-l lg:px-16">


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Make sidebars match by making the offset 65px and sticky.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
