### PR TITLE
fix(app): insert space after image to prevent adjacent deletion

### DIFF
--- a/app/src/components/contribute/editor/MarkdownLinkImageShortcutListener.tsx
+++ b/app/src/components/contribute/editor/MarkdownLinkImageShortcutListener.tsx
@@ -75,7 +75,8 @@ export default function MarkdownLinkImageShortcutListener() {
               $setSelection(rangeSelection);
 
               const imageNode = $createImageNode({ src, altText });
-              $insertNodes([imageNode]);
+              const spaceNode = $createTextNode(" ");
+              $insertNodes([imageNode, spaceNode]);
             });
             return;
           }


### PR DESCRIPTION
## Summary

When two images are inserted via the markdown shortcut (`![alt](url)`) in the contribution editor, they become adjacent Lexical nodes with no text separator. Selecting either image and pressing Backspace/Delete removes **both** images because Lexical's selection logic treats adjacent decorators as a single unit.

This fix adds a trailing space text node after each inserted image (matching how links already behave at line 114-116), ensuring adjacent images are always separated by a text node.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required