### PR TITLE
fix(app): handle 404 from search API gracefully on out-of-bounds pagination

### DIFF
--- a/app/src/components/ui/pagination-base.tsx
+++ b/app/src/components/ui/pagination-base.tsx
@@ -55,7 +55,7 @@ function PaginationLink({
       asChild
       variant={isActive ? "default" : "ghost"}
       size={size}
-      className={cn(className)}
+      className={cn("cursor-pointer", className)}
     >
       <a
         aria-current={isActive ? "page" : undefined}

--- a/app/src/routes/browse.tsx
+++ b/app/src/routes/browse.tsx
@@ -53,16 +53,23 @@ async function fetchGuides(
     return { found: total, items: guides };
   }
 
-  const { guides } = await search(
-    {
-      q,
-      page,
-      per_page: PAGE_SIZE,
-      ...filtersToParams({ scope: "guides", knowledgeType: kind }),
-    },
-    { signal }
-  );
-  return guides;
+  try {
+    const { guides } = await search(
+      {
+        q,
+        page,
+        per_page: PAGE_SIZE,
+        ...filtersToParams({ scope: "guides", knowledgeType: kind }),
+      },
+      { signal }
+    );
+    return guides;
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("404")) {
+      return { found: 0, items: [] };
+    }
+    throw e;
+  }
 }
 
 async function fetchObjectives(
@@ -77,16 +84,23 @@ async function fetchObjectives(
     return { found: total, items: objectives };
   }
 
-  const { objectives } = await search(
-    {
-      q,
-      page,
-      per_page: PAGE_SIZE,
-      ...filtersToParams({ scope: "objectives" }),
-    },
-    { signal }
-  );
-  return objectives;
+  try {
+    const { objectives } = await search(
+      {
+        q,
+        page,
+        per_page: PAGE_SIZE,
+        ...filtersToParams({ scope: "objectives" }),
+      },
+      { signal }
+    );
+    return objectives;
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("404")) {
+      return { found: 0, items: [] };
+    }
+    throw e;
+  }
 }
 
 export const Route = createFileRoute("/browse")({

--- a/app/src/routes/browse.tsx
+++ b/app/src/routes/browse.tsx
@@ -19,6 +19,7 @@ import { GuideCard } from "@/components/cards/GuideCard";
 import { Pagination } from "@/components/Pagination";
 import { SearchBar } from "@/components/SearchBar";
 import { SearchFilterMenu } from "@/components/SearchFilterMenu";
+import { ApiError } from "@/lib/api/apiHelpers";
 import { filtersToParams, search } from "@/lib/api/search";
 import { listGuidesPage } from "@/lib/api/guides";
 import { listObjectives } from "@/lib/api/objectives";
@@ -65,9 +66,8 @@ async function fetchGuides(
     );
     return guides;
   } catch (e) {
-    if (e instanceof Error && e.message.includes("404")) {
+    if (e instanceof ApiError && e.status === 404)
       return { found: 0, items: [] };
-    }
     throw e;
   }
 }
@@ -96,9 +96,8 @@ async function fetchObjectives(
     );
     return objectives;
   } catch (e) {
-    if (e instanceof Error && e.message.includes("404")) {
+    if (e instanceof ApiError && e.status === 404)
       return { found: 0, items: [] };
-    }
     throw e;
   }
 }
@@ -146,6 +145,7 @@ export const Route = createFileRoute("/browse")({
       ]);
       return { guides, objectives, error: null };
     } catch (e) {
+      if (signal.aborted) throw e;
       return {
         guides: null,
         objectives: null,


### PR DESCRIPTION
## Summary

When clicking **Next** pagination past the last page of search results on `/browse`, Typesense returns a **404** (out-of-bounds page). The loader previously caught this and displayed an error message. Now it catches 404 and returns an empty result set (`{ found: 0, items: [] }`), so the UI shows the existing empty state ("No guides found" / "No objectives found") instead of an error.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required