### PR TITLE
fix(app): discard malformed contribution drafts from local storage

### DIFF
--- a/app/src/components/ErrorFallback.tsx
+++ b/app/src/components/ErrorFallback.tsx
@@ -1,0 +1,29 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+export const ErrorFallback = ({ error }: { error: Error }) => {
+  return (
+    <main className="container mx-auto p-4 pt-16">
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia>
+            <img
+              src="/assets/adam/adam-cube-error.png"
+              alt="Adam mascot showing an error"
+              className="h-40 w-40 grayscale sm:h-56 sm:w-56"
+            />
+          </EmptyMedia>
+          <EmptyTitle className="data-label">Something went wrong</EmptyTitle>
+          <EmptyDescription className="data-value">
+            {error.message || "An unexpected error occurred."}
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </main>
+  );
+};

--- a/app/src/lib/contributionStorage.ts
+++ b/app/src/lib/contributionStorage.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from "react";
+import { z } from "zod";
 import type { ContributionType } from "@/types/contributions";
+import {
+  guideContributionSchema,
+  objectiveContributionSchema,
+  variantContributionSchema,
+} from "@/types/contributions";
 
 const STORAGE_KEYS: Record<ContributionType, string> = {
   guide: "bluelearn:contrib:guide",
@@ -14,23 +20,57 @@ export interface PersistedContributionDraft<T> {
   updatedAt: number;
 }
 
+// Checks a draft read back from local storage.
+const persistedDraftSchema = (data: z.ZodType) =>
+  z.object({
+    data,
+    revisionId: z
+      .string()
+      .nullish()
+      .transform((v) => v ?? null),
+    step: z.string().optional(),
+    updatedAt: z.number(),
+  });
+
+const DRAFT_SCHEMAS: Record<ContributionType, z.ZodType> = {
+  guide: persistedDraftSchema(guideContributionSchema),
+  variant: persistedDraftSchema(variantContributionSchema),
+  objective: persistedDraftSchema(objectiveContributionSchema),
+};
+
 /**
  * Safely reads a contribution draft from localStorage.
  * Handles SSR (returns null when window is not defined) and JSON parse errors.
+ * A draft that doesn't match the expected shape is dropped and cleared, since
+ * loading one into form state crashes the first render that touches it.
  */
 export function getStoredDraft<T>(
   type: ContributionType
 ): PersistedContributionDraft<T> | null {
   if (typeof window === "undefined") return null;
 
+  let parsed: unknown;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEYS[type]);
     if (!raw) return null;
-    return JSON.parse(raw) as PersistedContributionDraft<T>;
+    parsed = JSON.parse(raw);
   } catch (error) {
     console.warn(`Failed to read stored draft for ${type}:`, error);
+    clearStoredDraft(type);
     return null;
   }
+
+  const result = DRAFT_SCHEMAS[type].safeParse(parsed);
+  if (!result.success) {
+    console.warn(
+      `Discarding malformed stored draft for ${type}:`,
+      result.error
+    );
+    clearStoredDraft(type);
+    return null;
+  }
+
+  return result.data as PersistedContributionDraft<T>;
 }
 
 /**

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { NotFound } from "@/components/NotFound";
+import { ErrorFallback } from "@/components/ErrorFallback";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/lib/authContext";
 import { ThemeProvider } from "@/lib/themeProvider";
@@ -31,6 +32,7 @@ export const Route = createRootRoute({
     ],
   }),
   notFoundComponent: () => <NotFound />,
+  errorComponent: ErrorFallback,
   shellComponent: RootDocument,
 });
 

--- a/app/src/routes/contribute.tsx
+++ b/app/src/routes/contribute.tsx
@@ -4,6 +4,7 @@ import type { ContributionType } from "@/types/contributions";
 import ContributionFlow from "@/components/contribute/ContributionFlow";
 import { requireSession } from "@/lib/auth";
 import { RejectionFeedback } from "@/components/review/RejectionFeedback";
+import { ErrorFallback } from "@/components/ErrorFallback";
 
 export type ContributeSearch = {
   draft?: string;
@@ -54,6 +55,7 @@ export const Route = createFileRoute("/contribute")({
       todos,
     };
   },
+  errorComponent: ErrorFallback,
   component: RouteComponent,
 });
 

--- a/app/src/types/contributions.ts
+++ b/app/src/types/contributions.ts
@@ -1,49 +1,54 @@
-export type ContributionType = "guide" | "variant" | "objective";
+import { z } from "zod";
 
-export type GuideContribution = {
-  type: string;
-  title: string;
-  summary: string;
-  body: string;
-  subjects: Array<string>;
-  newSubjects: Array<{
-    id?: string;
-    name: string;
-    summary: string;
-  }>;
-  prereqs: Array<string>;
-  todoPrereqs: Array<{
-    title: string;
-    summary: string;
-  }>;
-};
+// Schemas are only used to check drafts restored from localStorage. Doesn't use shared
+// schemas because an empty field here is "" not null.
+export const contributionTypeSchema = z.enum(["guide", "variant", "objective"]);
 
-export type VariantContribution = {
-  type: string;
-  title: string;
-  summary: string;
-  baseGuide: string;
-  subjects: Array<string>;
-  newSubjects: Array<{
-    id?: string;
-    name: string;
-    summary: string;
-  }>;
-  body: string;
-};
+const newSubjectSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  summary: z.string(),
+});
 
-export type SubObjective = {
-  targetSlug: string;
-  selectedSlugs: Array<string>;
-  curatedSequence: Array<string>;
-};
+export const guideContributionSchema = z.object({
+  type: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  body: z.string(),
+  subjects: z.array(z.string()),
+  newSubjects: z.array(newSubjectSchema),
+  prereqs: z.array(z.string()),
+  todoPrereqs: z.array(z.object({ title: z.string(), summary: z.string() })),
+});
 
-export type ObjectiveContribution = {
-  title: string;
-  summary: string;
-  changeSummary: string;
-  targets: Array<string>;
-  featuredSubObjective: string;
-  subObjectives: Array<SubObjective>;
-  subjects: Array<string>;
-};
+export const variantContributionSchema = z.object({
+  type: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  baseGuide: z.string(),
+  subjects: z.array(z.string()),
+  newSubjects: z.array(newSubjectSchema),
+  body: z.string(),
+});
+
+export const subObjectiveSchema = z.object({
+  targetSlug: z.string(),
+  selectedSlugs: z.array(z.string()),
+  curatedSequence: z.array(z.string()),
+});
+
+export const objectiveContributionSchema = z.object({
+  title: z.string(),
+  summary: z.string(),
+  changeSummary: z.string(),
+  targets: z.array(z.string()),
+  featuredSubObjective: z.string(),
+  subObjectives: z.array(subObjectiveSchema),
+  subjects: z.array(z.string()),
+});
+
+export type ContributionType = z.infer<typeof contributionTypeSchema>;
+export type GuideContribution = z.infer<typeof guideContributionSchema>;
+export type VariantContribution = z.infer<typeof variantContributionSchema>;
+export type SubObjective = z.infer<typeof subObjectiveSchema>;
+export type ObjectiveContribution = z.infer<typeof objectiveContributionSchema>;


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Added a check to validate stored drafts in localStorage. Created a shared ErrorFallback component, which can render on any throw when the app is unmounted.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
