### PR TITLE
feat: add official guides

### DIFF
--- a/api/src/database.types.ts
+++ b/api/src/database.types.ts
@@ -1144,6 +1144,7 @@ export type Database = {
           guide_id: string | null
           guide_slug: string | null
           id: string | null
+          is_official: boolean | null
           knowledge_type: Database["public"]["Enums"]["knowledge_type"] | null
           revision_id: string | null
           status: Database["public"]["Enums"]["node_status"] | null

--- a/api/src/database.types.ts
+++ b/api/src/database.types.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -20,6 +40,7 @@ export type Database = {
           created_at: string
           forked_from_guide_base_id: string | null
           id: string
+          is_official: boolean
           knowledge_type: Database["public"]["Enums"]["knowledge_type"]
           slug: string | null
           status: Database["public"]["Enums"]["node_status"]
@@ -30,6 +51,7 @@ export type Database = {
           created_at?: string
           forked_from_guide_base_id?: string | null
           id?: string
+          is_official?: boolean
           knowledge_type: Database["public"]["Enums"]["knowledge_type"]
           slug?: string | null
           status?: Database["public"]["Enums"]["node_status"]
@@ -40,6 +62,7 @@ export type Database = {
           created_at?: string
           forked_from_guide_base_id?: string | null
           id?: string
+          is_official?: boolean
           knowledge_type?: Database["public"]["Enums"]["knowledge_type"]
           slug?: string | null
           status?: Database["public"]["Enums"]["node_status"]
@@ -1178,6 +1201,12 @@ export type Database = {
         }
         Returns: string
       }
+      eligible_panel_admins: {
+        Args: { p_created_by: string; p_panel_id?: string }
+        Returns: {
+          id: string
+        }[]
+      }
       eligible_panel_verifiers: {
         Args: { p_created_by: string; p_panel_id?: string }
         Returns: {
@@ -1242,9 +1271,13 @@ export type Database = {
       }
     }
     Enums: {
-      app_role: "verifier" | "moderator" | "curator" | "admin"
+      app_role: "verifier" | "moderator" | "curator" | "admin" | "official"
       case_status: "pending" | "in_review" | "approved" | "rejected"
-      case_type: "guide_publish" | "guide_edit"
+      case_type:
+        | "guide_publish"
+        | "guide_edit"
+        | "official_publish"
+        | "official_edit"
       decision_reason:
         | "hierarchy_issue"
         | "factual_error"
@@ -1396,11 +1429,19 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
-      app_role: ["verifier", "moderator", "curator", "admin"],
+      app_role: ["verifier", "moderator", "curator", "admin", "official"],
       case_status: ["pending", "in_review", "approved", "rejected"],
-      case_type: ["guide_publish", "guide_edit"],
+      case_type: [
+        "guide_publish",
+        "guide_edit",
+        "official_publish",
+        "official_edit",
+      ],
       decision_reason: [
         "hierarchy_issue",
         "factual_error",
@@ -1432,3 +1473,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/api/src/lib/review-policy.ts
+++ b/api/src/lib/review-policy.ts
@@ -8,4 +8,8 @@ type CaseType = Database["public"]["Enums"]["case_type"];
 export const PANEL_POLICY_DEFAULTS: Record<CaseType, number> = {
   guide_publish: 3,
   guide_edit: 3,
+
+  // Official panels seat every eligible admin, so the RPC ignores these.
+  official_publish: 3,
+  official_edit: 3,
 };

--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -277,7 +277,7 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
   const { data: guide, error } = await supabase
     .from("guide_bases")
     .select(
-      `id, slug, knowledge_type, status, created_at, updated_at, ${CANONICAL_CONTENT}`
+      `id, slug, knowledge_type, status, created_at, updated_at, is_official, ${CANONICAL_CONTENT}`
     )
     .eq("slug", slug)
     .maybeSingle();
@@ -309,6 +309,7 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
     created_at: guide.created_at,
     tags: subjects.map((s) => ({ slug: s.slug, name: s.name })),
     prerequisites,
+    is_official: guide.is_official,
   };
 
   return detail;

--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -35,12 +35,13 @@ type GuideCardRow = Pick<
   | "revision_id"
   | "summary"
   | "word_count"
+  | "is_official"
 >;
 
 // Columns of published_guides a card needs.
 export const PUBLISHED_GUIDE_SELECT =
   `id, base_slug, title, knowledge_type, status, created_at,
-   author_id, revision_id, summary, word_count` as const;
+   author_id, revision_id, summary, word_count, is_official` as const;
 
 type WalkthroughRPC = {
   nodes: (Omit<Walkthrough["nodes"][number], "duration_minutes"> & {
@@ -162,6 +163,7 @@ export async function buildGuideListItems(
     author: card.author_id ? (usernames.get(card.author_id) ?? null) : null,
     duration_minutes: readingMinutes(card.word_count ?? 0),
     tags: tagsByRevision.get(card.revision_id!) ?? [],
+    is_official: card.is_official!,
   }));
 }
 
@@ -515,6 +517,7 @@ export async function getVariantBySlug(
     .from("guides")
     .select(
       `id, guide_base_id, slug, status, author_id,
+       base:guide_bases!guides_guide_base_id_fkey(is_official),
        current:guide_revisions!guides_current_revision_id_fkey(id, title, summary, body, word_count, created_at)`
     )
     .eq("guide_base_id", baseId)
@@ -546,7 +549,7 @@ export async function getVariantBySlug(
     throw new ServiceError("Failed to load vote tally", 500);
   }
 
-  const { author_id, current, ...rest } = variant;
+  const { author_id, current, base, ...rest } = variant;
 
   return {
     variant: {
@@ -564,6 +567,7 @@ export async function getVariantBySlug(
       tags: tags.map((s) => ({ slug: s.slug, name: s.name })),
       duration_minutes: readingMinutes(current?.word_count ?? 0),
       votes: { up: tally?.upvotes ?? 0, down: tally?.downvotes ?? 0 },
+      is_official: base?.is_official ?? false,
     },
   };
 }

--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -305,6 +305,7 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
     variant_slug: canonical?.slug ?? null,
     title: current?.title ?? "",
     author: authorId ? (usernames.get(authorId) ?? "") : "",
+    knowledge_type: guide.knowledge_type,
     summary: current?.summary ?? null,
     body: current?.body ?? null,
     duration_minutes: readingMinutes(current?.word_count ?? 0),
@@ -517,7 +518,7 @@ export async function getVariantBySlug(
     .from("guides")
     .select(
       `id, guide_base_id, slug, status, author_id,
-       base:guide_bases!guides_guide_base_id_fkey(is_official),
+       base:guide_bases!guides_guide_base_id_fkey(is_official, knowledge_type),
        current:guide_revisions!guides_current_revision_id_fkey(id, title, summary, body, word_count, created_at)`
     )
     .eq("guide_base_id", baseId)
@@ -568,6 +569,7 @@ export async function getVariantBySlug(
       duration_minutes: readingMinutes(current?.word_count ?? 0),
       votes: { up: tally?.upvotes ?? 0, down: tally?.downvotes ?? 0 },
       is_official: base?.is_official ?? false,
+      knowledge_type: base?.knowledge_type ?? "theoretical",
     },
   };
 }

--- a/app/src/components/GuideActionModals.tsx
+++ b/app/src/components/GuideActionModals.tsx
@@ -16,7 +16,7 @@ export type GuideModalType =
   | "contributors"
   | "revisions";
 
-export const GUIDE_ACTIONS: Array<{
+const GUIDE_ACTIONS: Array<{
   icon: typeof Replace;
   label: string;
   type: GuideModalType;
@@ -27,12 +27,18 @@ export const GUIDE_ACTIONS: Array<{
   { icon: History, label: "View Revisions", type: "revisions" },
 ];
 
+export const guideActions = (isOfficial: boolean) =>
+  isOfficial
+    ? GUIDE_ACTIONS.filter((action) => action.type !== "variants")
+    : GUIDE_ACTIONS;
+
 type GuideActionModalsProps = {
   active: GuideModalType | null;
   onOpenChange: (open: boolean) => void;
   slug: string;
   currentVariantSlug: string | null;
   variantId: string | null;
+  isOfficial?: boolean;
 };
 
 export function GuideActionModals({
@@ -41,6 +47,7 @@ export function GuideActionModals({
   slug,
   currentVariantSlug,
   variantId,
+  isOfficial = false,
 }: GuideActionModalsProps) {
   const fetchContributors = useCallback(
     () => getVariantContributors(variantId ?? ""),
@@ -60,7 +67,7 @@ export function GuideActionModals({
   return (
     <>
       <VariantsModal
-        open={active === "variants"}
+        open={!isOfficial && active === "variants"}
         onOpenChange={onOpenChange}
         slug={slug}
         currentVariantSlug={currentVariantSlug}

--- a/app/src/components/GuideMobileMenu.tsx
+++ b/app/src/components/GuideMobileMenu.tsx
@@ -13,8 +13,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  GUIDE_ACTIONS,
   GuideActionModals,
+  guideActions,
 } from "@/components/GuideActionModals";
 import { PrerequisitesModal } from "@/components/modals/PrerequisitesModal";
 
@@ -25,6 +25,7 @@ type GuideMobileMenuProps = {
   guideTitle: string;
   menuItems: Array<{ label: string; to: string; icon: React.ReactNode }>;
   prerequisites?: Array<GuideReference>;
+  isOfficial?: boolean;
 };
 
 export function GuideMobileMenu({
@@ -34,6 +35,7 @@ export function GuideMobileMenu({
   guideTitle,
   menuItems,
   prerequisites,
+  isOfficial = false,
 }: GuideMobileMenuProps) {
   const [activeModal, setActiveModal] = useState<
     GuideModalType | "prerequisites" | null
@@ -66,7 +68,7 @@ export function GuideMobileMenu({
 
           <DropdownMenuSeparator />
 
-          {GUIDE_ACTIONS.map((action) => (
+          {guideActions(isOfficial).map((action) => (
             <DropdownMenuItem
               key={action.type}
               className="cursor-pointer text-xs"
@@ -95,6 +97,7 @@ export function GuideMobileMenu({
         slug={slug}
         currentVariantSlug={currentVariantSlug}
         variantId={variantId}
+        isOfficial={isOfficial}
       />
 
       {prerequisites && (

--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkDirective from "remark-directive";
 
-import { BadgeCheck, Calendar, Clock, User } from "lucide-react";
+import { Calendar, Clock, ShieldCheck, User } from "lucide-react";
 import { createElement } from "react";
 import type { ReactElement } from "react";
 import type { Guide } from "@bluelearn/schemas";
@@ -90,10 +90,13 @@ export const GuideReader = ({
             {isOfficial && (
               <Badge
                 variant="outline"
-                className="mono-micro shrink-0 gap-1 rounded-full border bg-badge tracking-[0.08em] text-badge-foreground"
+                className="mono-micro h-6 shrink-0 gap-0.5 rounded-full border bg-transparent tracking-[0.08em] text-primary [&>svg]:size-[18px]!"
               >
-                <BadgeCheck className="h-3 w-3 text-primary" />
-                Official
+                <ShieldCheck
+                  className="fill-primary text-background"
+                  strokeWidth={2.5}
+                />
+                <span className="translate-y-[0.25px]">Official</span>
               </Badge>
             )}
             {guideType && (

--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -35,7 +35,10 @@ const sanitizeSchema = {
 // subjects whose slug is not minted yet, so either identifier will do.
 type ReaderTag = { id?: string; slug?: string; name: string };
 
-export type ReaderGuide = Omit<Guide, "tags" | "variant_id" | "is_official"> & {
+export type ReaderGuide = Omit<
+  Guide,
+  "tags" | "variant_id" | "is_official" | "knowledge_type"
+> & {
   tags: Array<ReaderTag>;
 };
 
@@ -90,7 +93,7 @@ export const GuideReader = ({
             {isOfficial && (
               <Badge
                 variant="outline"
-                className="mono-micro h-6 shrink-0 gap-0.5 rounded-full border bg-transparent tracking-[0.08em] text-primary [&>svg]:size-[18px]!"
+                className="mono-micro h-6 shrink-0 gap-0.5 rounded-full border border-badge-border bg-transparent tracking-[0.08em] text-primary [&>svg]:size-[18px]!"
               >
                 <ShieldCheck
                   className="fill-primary text-background"

--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkDirective from "remark-directive";
 
-import { Calendar, Clock, User } from "lucide-react";
+import { BadgeCheck, Calendar, Clock, User } from "lucide-react";
 import { createElement } from "react";
 import type { ReactElement } from "react";
 import type { Guide } from "@bluelearn/schemas";
@@ -35,7 +35,7 @@ const sanitizeSchema = {
 // subjects whose slug is not minted yet, so either identifier will do.
 type ReaderTag = { id?: string; slug?: string; name: string };
 
-export type ReaderGuide = Omit<Guide, "tags" | "variant_id"> & {
+export type ReaderGuide = Omit<Guide, "tags" | "variant_id" | "is_official"> & {
   tags: Array<ReaderTag>;
 };
 
@@ -43,12 +43,14 @@ type PropTypes = {
   guide: ReaderGuide;
   guideType?: GuideType;
   showToc?: boolean;
+  isOfficial?: boolean;
 };
 
 export const GuideReader = ({
   guide,
   guideType,
   showToc = false,
+  isOfficial = false,
 }: PropTypes) => {
   const created = new Date(guide.created_at);
   const createdLabel = Number.isNaN(created.getTime())
@@ -84,15 +86,26 @@ export const GuideReader = ({
             {showToc && <GuideToc body={guide.body ?? ""} />}
             <h1 className="text-3xl font-bold">{guide.title}</h1>
           </div>
-          {guideType && (
-            <Badge
-              key={guideType}
-              variant="outline"
-              className="mono-micro shrink-0 rounded-full border bg-badge tracking-[0.08em] text-badge-foreground"
-            >
-              {guideType}
-            </Badge>
-          )}
+          <div className="flex shrink-0 items-center gap-2">
+            {isOfficial && (
+              <Badge
+                variant="outline"
+                className="mono-micro shrink-0 gap-1 rounded-full border bg-badge tracking-[0.08em] text-badge-foreground"
+              >
+                <BadgeCheck className="h-3 w-3 text-primary" />
+                Official
+              </Badge>
+            )}
+            {guideType && (
+              <Badge
+                key={guideType}
+                variant="outline"
+                className="mono-micro shrink-0 rounded-full border bg-badge tracking-[0.08em] text-badge-foreground"
+              >
+                {guideType}
+              </Badge>
+            )}
+          </div>
         </div>
 
         <div className="mono-micro my-2 flex flex-wrap items-center gap-2.5 text-muted-foreground">

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -16,13 +16,13 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Logo } from "@/components/Logo";
 
-// `role`, when set, hides the item from anyone who doesn't hold it.
-const navItems: Array<{ label: string; to: string; role?: string }> = [
+// `roles`, when set, hides the item from anyone holding none of them.
+const navItems: Array<{ label: string; to: string; roles?: Array<string> }> = [
   { label: "Browse", to: "/browse" },
   { label: "Subjects", to: "/subjects" },
   { label: "Objectives", to: "/objectives" },
   { label: "Todo", to: "/todos" },
-  { label: "Review", to: "/review", role: "verifier" },
+  { label: "Review", to: "/review", roles: ["verifier", "admin"] },
 ];
 
 // Profile isn't here because its link needs the signed-in username.
@@ -35,7 +35,7 @@ export function Navbar() {
   const navigate = useNavigate();
 
   const visibleNavItems = navItems.filter(
-    (item) => !item.role || roles.includes(item.role)
+    (item) => !item.roles || item.roles.some((r) => roles.includes(r))
   );
 
   function handleSearch(e: React.FormEvent) {

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -12,7 +12,7 @@ import type {
   VariantContribution,
 } from "@/types/contributions";
 import type { GuideType } from "@/types/guides";
-import type { Guide } from "@bluelearn/schemas";
+import type { ReaderGuide } from "@/components/GuideReader";
 import { addGuideVariant, createGuide, listGuides } from "@/lib/api/guides";
 import { getMyIdentity } from "@/lib/api/identity";
 import { listSubjects } from "@/lib/api/subjects";
@@ -515,7 +515,7 @@ function Inner({
 
   // Shape the in-progress form as a Guide, so the submit step can render it with
   // the same component the published page uses.
-  const previewGuide: Guide = useMemo(() => {
+  const previewGuide: ReaderGuide = useMemo(() => {
     const nameById = new Map(
       subjectOptions.map((s) => [s.id, s.name] as const)
     );
@@ -552,7 +552,7 @@ function Inner({
     };
   }, [guideContData, subjectOptions, guideOptions, username]);
 
-  const previewVariant: Guide = useMemo(() => {
+  const previewVariant: ReaderGuide = useMemo(() => {
     const nameById = new Map(
       subjectOptions.map((s) => [s.id, s.name] as const)
     );

--- a/app/src/components/contribute/steps/PreviewGuide.tsx
+++ b/app/src/components/contribute/steps/PreviewGuide.tsx
@@ -1,15 +1,15 @@
 import "katex/dist/katex.min.css";
 
-import type { Guide } from "@bluelearn/schemas";
 import type { GuideType } from "@/types/guides";
 import type { ContributionType } from "@/types/contributions";
+import type { ReaderGuide } from "@/components/GuideReader";
 import { GuideReader } from "@/components/GuideReader";
 import { StepperActionHeader } from "@/components/contribute/StepperActionHeader";
 
 type PropTypes = {
   Stepper: any;
   type: ContributionType | null;
-  guide: Guide;
+  guide: ReaderGuide;
   guideType?: GuideType;
   onSaveDraft: () => void;
   onPublish: () => void;

--- a/app/src/components/contribute/steps/Submit.tsx
+++ b/app/src/components/contribute/steps/Submit.tsx
@@ -1,14 +1,14 @@
 import "katex/dist/katex.min.css";
 
-import type { Guide } from "@bluelearn/schemas";
 import type { GuideType } from "@/types/guides";
 
+import type { ReaderGuide } from "@/components/GuideReader";
 import { GuideReader } from "@/components/GuideReader";
 import { StepperActionHeader } from "@/components/contribute/StepperActionHeader";
 
 type PropTypes = {
   Stepper: any;
-  guide: Guide;
+  guide: ReaderGuide;
   guideType?: GuideType;
   onSaveDraft: () => void;
   onPublish: () => void;

--- a/app/src/components/contribute/steps/VariantDetails.tsx
+++ b/app/src/components/contribute/steps/VariantDetails.tsx
@@ -138,7 +138,10 @@ export const VariantDetails = ({
 
           <Combobox
             items={guides
-              .filter((g): g is typeof g & { slug: string } => !!g.slug)
+              .filter(
+                (g): g is typeof g & { slug: string } =>
+                  !!g.slug && !g.is_official
+              )
               .map((g) => {
                 return {
                   value: g.slug,

--- a/app/src/components/sidebar/GuideSidebar.tsx
+++ b/app/src/components/sidebar/GuideSidebar.tsx
@@ -5,7 +5,7 @@ import { CollapsibleSection } from "@/components/CollapsibleSection";
 import { extractHeadings } from "@/lib/guideUtils";
 
 type PropTypes = {
-  guide: Omit<Guide, "variant_id">;
+  guide: Omit<Guide, "variant_id" | "is_official">;
   slug: string;
   sidebarActions?: React.ReactNode;
   reviewSection?: React.ReactNode;

--- a/app/src/components/sidebar/GuideSidebarActions.tsx
+++ b/app/src/components/sidebar/GuideSidebarActions.tsx
@@ -8,20 +8,22 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  GUIDE_ACTIONS,
   GuideActionModals,
+  guideActions,
 } from "@/components/GuideActionModals";
 
 type PropsTypes = {
   slug: string;
   currentVariantSlug: string | null;
   variantId: string | null;
+  isOfficial?: boolean;
 };
 
 export const GuideSidebarActions = ({
   slug,
   currentVariantSlug,
   variantId,
+  isOfficial = false,
 }: PropsTypes) => {
   const [activeModal, setActiveModal] = useState<GuideModalType | null>(null);
   const close = (open: boolean) => !open && setActiveModal(null);
@@ -29,7 +31,7 @@ export const GuideSidebarActions = ({
   return (
     <>
       <div className="flex items-center justify-start gap-4">
-        {GUIDE_ACTIONS.map((action) => (
+        {guideActions(isOfficial).map((action) => (
           <Tooltip key={action.label}>
             <TooltipTrigger asChild>
               <Button
@@ -55,6 +57,7 @@ export const GuideSidebarActions = ({
         slug={slug}
         currentVariantSlug={currentVariantSlug}
         variantId={variantId}
+        isOfficial={isOfficial}
       />
     </>
   );

--- a/app/src/components/sidebar/ReviewSidebar.tsx
+++ b/app/src/components/sidebar/ReviewSidebar.tsx
@@ -59,7 +59,9 @@ export const ReviewSidebar = ({
 
   const subjects = revision?.tags ?? [];
 
-  const isEdit = revisionData.case.case_type === "guide_edit";
+  const isEdit =
+    revisionData.case.case_type === "guide_edit" ||
+    revisionData.case.case_type === "official_edit";
 
   const priorDecision = revisionData.viewer_decision;
   const hasVoted = priorDecision !== null;

--- a/app/src/components/sidebar/ReviewSidebar.tsx
+++ b/app/src/components/sidebar/ReviewSidebar.tsx
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { Check, ExternalLink, Scroll, X } from "lucide-react";
+import { Check, ExternalLink, Scroll, ShieldCheck, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useRouter } from "@tanstack/react-router";
 
@@ -61,6 +61,10 @@ export const ReviewSidebar = ({
 
   const isEdit =
     revisionData.case.case_type === "guide_edit" ||
+    revisionData.case.case_type === "official_edit";
+
+  const isOfficial =
+    revisionData.case.case_type === "official_publish" ||
     revisionData.case.case_type === "official_edit";
 
   const priorDecision = revisionData.viewer_decision;
@@ -213,12 +217,29 @@ export const ReviewSidebar = ({
             <DetailRow
               label="Case Type"
               value={
-                <Badge
-                  variant="outline"
-                  className="border-badge-border bg-badge font-mono tracking-[0.06em] text-badge-foreground uppercase"
-                >
-                  {isEdit ? "Guide Revision" : "Guide Creation"}
-                </Badge>
+                isOfficial ? (
+                  <Badge
+                    variant="outline"
+                    className="h-6 gap-0.5 border-badge-border bg-transparent font-mono tracking-[0.06em] text-primary uppercase [&>svg]:size-[18px]!"
+                  >
+                    <ShieldCheck
+                      className="fill-primary text-background"
+                      strokeWidth={2.5}
+                    />
+                    <span className="translate-y-[0.25px]">
+                      {isEdit
+                        ? "Official Guide Revision"
+                        : "Official Guide Creation"}
+                    </span>
+                  </Badge>
+                ) : (
+                  <Badge
+                    variant="outline"
+                    className="border-badge-border bg-badge font-mono tracking-[0.06em] text-badge-foreground uppercase"
+                  >
+                    {isEdit ? "Guide Revision" : "Guide Creation"}
+                  </Badge>
+                )
               }
             />
             <DetailRow

--- a/app/src/lib/authContext.tsx
+++ b/app/src/lib/authContext.tsx
@@ -111,7 +111,7 @@ export function useAuth() {
   return useContext(AuthContext);
 }
 
-export function useRequireRole(role: string) {
+export function useRequireRole(role: string | Array<string>) {
   const { session, roles, loading, rolesLoading } = useAuth();
   const navigate = useNavigate();
   const resolving = loading || rolesLoading;
@@ -121,7 +121,11 @@ export function useRequireRole(role: string) {
   }, [resolving, session, navigate]);
 
   if (resolving || !session) return "pending" as const;
-  return roles.includes(role) ? ("allowed" as const) : ("not-found" as const);
+
+  const allowed = Array.isArray(role) ? role : [role];
+  return allowed.some((r) => roles.includes(r))
+    ? ("allowed" as const)
+    : ("not-found" as const);
 }
 
 // Redirect already-authed users away from auth-only pages (login, register).

--- a/app/src/routes/guides/$slug/$variantSlug/edit.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/edit.tsx
@@ -4,7 +4,7 @@ import { ChevronRight } from "lucide-react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import type { Guide } from "@bluelearn/schemas";
+import type { ReaderGuide } from "@/components/GuideReader";
 import type { GuideContribution } from "@/types/contributions";
 import type { GuideType } from "@/types/guides";
 import { listGuides } from "@/lib/api/guides";
@@ -123,7 +123,7 @@ function RouteComponent() {
     return () => controller.abort();
   }, []);
 
-  const previewGuide: Guide = useMemo(() => {
+  const previewGuide: ReaderGuide = useMemo(() => {
     const nameById = new Map(
       subjectOptions.map((s) => [s.id, s.name] as const)
     );

--- a/app/src/routes/guides/$slug/$variantSlug/index.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/index.tsx
@@ -69,6 +69,7 @@ function RouteComponent() {
     variant_slug: variant.slug,
     title: current.title ?? "",
     author: variant.author,
+    knowledge_type: variant.knowledge_type,
     summary: current.summary,
     body: current.body,
     duration_minutes: variant.duration_minutes,
@@ -234,7 +235,12 @@ function RouteComponent() {
 
           <Separator className="mb-8" />
 
-          <GuideReader guide={guide} showToc isOfficial={variant.is_official} />
+          <GuideReader
+            guide={guide}
+            guideType={guide.knowledge_type}
+            showToc
+            isOfficial={variant.is_official}
+          />
         </main>
       </section>
     </div>

--- a/app/src/routes/guides/$slug/$variantSlug/index.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/index.tsx
@@ -83,11 +83,15 @@ function RouteComponent() {
       to: `/guides/${slug}/${variantSlug}/edit`,
       icon: <Pencil className="h-4 w-4" />,
     },
-    {
-      label: "Create Variant",
-      to: "/contribute",
-      icon: <Plus className="h-4 w-4" />,
-    },
+    ...(variant.is_official
+      ? []
+      : [
+          {
+            label: "Create Variant",
+            to: "/contribute",
+            icon: <Plus className="h-4 w-4" />,
+          },
+        ]),
   ];
 
   const breadcrumbs = buildBreadcrumbs(guide.title, breadcrumbOrigin);
@@ -101,6 +105,7 @@ function RouteComponent() {
               slug={slug}
               currentVariantSlug={variant.slug}
               variantId={variant.id}
+              isOfficial={variant.is_official}
             />
           }
           guide={guide}
@@ -199,6 +204,7 @@ function RouteComponent() {
                 variantId={variant.id}
                 guideTitle={guide.title}
                 menuItems={guideMenuItems}
+                isOfficial={variant.is_official}
               />
 
               <DropdownMenu>
@@ -228,7 +234,7 @@ function RouteComponent() {
 
           <Separator className="mb-8" />
 
-          <GuideReader guide={guide} showToc />
+          <GuideReader guide={guide} showToc isOfficial={variant.is_official} />
         </main>
       </section>
     </div>

--- a/app/src/routes/guides/$slug/index.tsx
+++ b/app/src/routes/guides/$slug/index.tsx
@@ -67,11 +67,15 @@ function RouteComponent() {
       to: `/guides/${slug}/${guide.variant_slug}/edit`,
       icon: <Pencil className="h-4 w-4" />,
     },
-    {
-      label: "Create Variant",
-      to: "/contribute",
-      icon: <Plus className="h-4 w-4" />,
-    },
+    ...(guide.is_official
+      ? []
+      : [
+          {
+            label: "Create Variant",
+            to: "/contribute",
+            icon: <Plus className="h-4 w-4" />,
+          },
+        ]),
     // { label: "Report", to: "/report", <Flag className="h-4 w-4" /> },// TODO: Implement post v1
   ];
 
@@ -86,6 +90,7 @@ function RouteComponent() {
               slug={slug}
               currentVariantSlug={guide.variant_slug}
               variantId={guide.variant_id}
+              isOfficial={guide.is_official}
             />
           }
           guide={guide}
@@ -193,6 +198,7 @@ function RouteComponent() {
                 guideTitle={guide.title}
                 menuItems={guideMenuItems}
                 prerequisites={guide.prerequisites}
+                isOfficial={guide.is_official}
               />
 
               <DropdownMenu>
@@ -224,7 +230,7 @@ function RouteComponent() {
 
           {/* Header */}
 
-          <GuideReader guide={guide} showToc />
+          <GuideReader guide={guide} showToc isOfficial={guide.is_official} />
         </main>
       </section>
     </div>

--- a/app/src/routes/guides/$slug/index.tsx
+++ b/app/src/routes/guides/$slug/index.tsx
@@ -230,7 +230,12 @@ function RouteComponent() {
 
           {/* Header */}
 
-          <GuideReader guide={guide} showToc isOfficial={guide.is_official} />
+          <GuideReader
+            guide={guide}
+            guideType={guide.knowledge_type}
+            showToc
+            isOfficial={guide.is_official}
+          />
         </main>
       </section>
     </div>

--- a/app/src/routes/review.$caseId.tsx
+++ b/app/src/routes/review.$caseId.tsx
@@ -90,7 +90,7 @@ function RouteComponent() {
       slug: "",
       variant_slug: null,
       title: revision.title ?? "",
-      author: "",
+      author: revision.author_username,
       summary: revision.summary ?? null,
       body: revision.body ?? null,
       duration_minutes: revision.duration_minutes,

--- a/app/src/routes/review.$caseId.tsx
+++ b/app/src/routes/review.$caseId.tsx
@@ -60,7 +60,9 @@ function RouteComponent() {
 
   // Only an edit has something to be compared against. A creation is the first
   // version of its guide, so there is no live revision to diff against.
-  const isEdit = revisionData.case.case_type === "guide_edit";
+  const isEdit =
+    revisionData.case.case_type === "guide_edit" ||
+    revisionData.case.case_type === "official_edit";
 
   const [view, setView] = useState<"guide" | "changes">("guide");
   const [diff, setDiff] = useState<RevisionDiffData | null>(null);

--- a/app/src/routes/review.index.tsx
+++ b/app/src/routes/review.index.tsx
@@ -124,7 +124,7 @@ function CaseGrid({ cases }: { cases: Array<QueueCase> }) {
           <div className="rounded-md border bg-background p-4 shadow-none transition-colors hover:bg-muted">
             <div className="flex items-center justify-between">
               <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
-                {c.case_type === "guide_edit"
+                {c.case_type === "guide_edit" || c.case_type === "official_edit"
                   ? "Guide Revision"
                   : "Guide Creation"}
               </p>

--- a/app/src/routes/review.index.tsx
+++ b/app/src/routes/review.index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
-import { ShieldCheck } from "lucide-react";
 
 import type { QueueCase } from "@/lib/api/reviews";
 import { NotFound } from "@/components/NotFound";
@@ -115,64 +114,52 @@ function reviewerStatus(decision: QueueCase["decision"]) {
 function CaseGrid({ cases }: { cases: Array<QueueCase> }) {
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-      {cases.map((c) => (
-        <Link
-          key={c.id}
-          to={ReviewCaseIdRoute.to}
-          params={{ caseId: c.id }}
-          className="block"
-        >
-          <div className="rounded-md border bg-background p-4 shadow-none transition-colors hover:bg-muted">
-            <div className="flex items-center justify-between">
-              {c.case_type === "official_publish" ||
-              c.case_type === "official_edit" ? (
+      {cases.map((c) => {
+        const isOfficial =
+          c.case_type === "official_publish" || c.case_type === "official_edit";
+        const isEdit =
+          c.case_type === "guide_edit" || c.case_type === "official_edit";
+
+        return (
+          <Link
+            key={c.id}
+            to={ReviewCaseIdRoute.to}
+            params={{ caseId: c.id }}
+            className="block"
+          >
+            <div className="rounded-md border bg-background p-4 shadow-none transition-colors hover:bg-muted">
+              <div className="flex items-center justify-between">
+                <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
+                  {isOfficial ? "Official " : ""}
+                  {isEdit ? "Guide Revision" : "Guide Creation"}
+                </p>
                 <Badge
                   variant="outline"
-                  className="mono-micro h-6 gap-0.5 rounded-full border border-badge-border bg-transparent tracking-[0.08em] text-primary [&>svg]:size-[18px]!"
+                  className="mono-micro rounded-full border border-badge-border bg-badge tracking-[0.08em] text-badge-foreground"
                 >
-                  <ShieldCheck
-                    className="fill-primary text-background"
-                    strokeWidth={2.5}
-                  />
-                  <span className="translate-y-[0.25px]">
-                    {c.case_type === "official_edit"
-                      ? "Official Guide Revision"
-                      : "Official Guide Creation"}
-                  </span>
+                  {reviewerStatus(c.decision)}
                 </Badge>
-              ) : (
-                <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
-                  {c.case_type === "guide_edit"
-                    ? "Guide Revision"
-                    : "Guide Creation"}
+              </div>
+
+              <h3 className="mt-2 text-xl font-semibold tracking-tight">
+                {c.title ?? "Untitled Guide"}
+              </h3>
+
+              <div>
+                <p className="mt-2 font-mono text-[11px] tracking-[0.08em] text-muted-foreground uppercase">
+                  {new Date(c.created_at).toLocaleDateString("en-GB", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}
                 </p>
-              )}
-              <Badge
-                variant="outline"
-                className="mono-micro rounded-full border border-badge-border bg-badge tracking-[0.08em] text-badge-foreground"
-              >
-                {reviewerStatus(c.decision)}
-              </Badge>
+
+                <CaseTimer expiresAt={c.expires_at} decision={c.decision} />
+              </div>
             </div>
-
-            <h3 className="mt-2 text-xl font-semibold tracking-tight">
-              {c.title ?? "Untitled Guide"}
-            </h3>
-
-            <div>
-              <p className="mt-2 font-mono text-[11px] tracking-[0.08em] text-muted-foreground uppercase">
-                {new Date(c.created_at).toLocaleDateString("en-GB", {
-                  day: "numeric",
-                  month: "long",
-                  year: "numeric",
-                })}
-              </p>
-
-              <CaseTimer expiresAt={c.expires_at} decision={c.decision} />
-            </div>
-          </div>
-        </Link>
-      ))}
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/app/src/routes/review.index.tsx
+++ b/app/src/routes/review.index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
+import { ShieldCheck } from "lucide-react";
 
 import type { QueueCase } from "@/lib/api/reviews";
 import { NotFound } from "@/components/NotFound";
@@ -123,11 +124,29 @@ function CaseGrid({ cases }: { cases: Array<QueueCase> }) {
         >
           <div className="rounded-md border bg-background p-4 shadow-none transition-colors hover:bg-muted">
             <div className="flex items-center justify-between">
-              <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
-                {c.case_type === "guide_edit" || c.case_type === "official_edit"
-                  ? "Guide Revision"
-                  : "Guide Creation"}
-              </p>
+              {c.case_type === "official_publish" ||
+              c.case_type === "official_edit" ? (
+                <Badge
+                  variant="outline"
+                  className="mono-micro h-6 gap-0.5 rounded-full border border-badge-border bg-transparent tracking-[0.08em] text-primary [&>svg]:size-[18px]!"
+                >
+                  <ShieldCheck
+                    className="fill-primary text-background"
+                    strokeWidth={2.5}
+                  />
+                  <span className="translate-y-[0.25px]">
+                    {c.case_type === "official_edit"
+                      ? "Official Guide Revision"
+                      : "Official Guide Creation"}
+                  </span>
+                </Badge>
+              ) : (
+                <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
+                  {c.case_type === "guide_edit"
+                    ? "Guide Revision"
+                    : "Guide Creation"}
+                </p>
+              )}
               <Badge
                 variant="outline"
                 className="mono-micro rounded-full border border-badge-border bg-badge tracking-[0.08em] text-badge-foreground"

--- a/app/src/routes/review.index.tsx
+++ b/app/src/routes/review.index.tsx
@@ -43,7 +43,7 @@ function Shell({ children }: { children: React.ReactNode }) {
 
 function RouteComponent() {
   const cases = Route.useLoaderData();
-  const access = useRequireRole("verifier");
+  const access = useRequireRole(["verifier", "admin"]);
 
   if (access === "pending") return null;
   if (access === "not-found") return <NotFound />;

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -27,14 +27,14 @@ The schema deliberately keeps the database source of truth small:
 - `bio`: optional short profile text.
 - `is_suspended`: optional flag for moderation actions against a member, kept separate from roles so a role is not silently lost on suspension.
 
-`roles` is not a column on `profiles`. Every user is a `learner` implicitly; granted roles (`verifier`, `moderator`, `curator`, `admin`) live in `user_roles`.
+`roles` is not a column on `profiles`. Every user is a `learner` implicitly; granted roles (`verifier`, `moderator`, `curator`, `admin`, `official`) live in `user_roles`.
 
 ### `user_roles`
 
 The roles a user holds. A user may hold several at once (e.g. both `verifier` and `moderator`). `learner` is the implicit baseline and is not stored here; absence of any row means learner-only.
 
 - `user_id`: FK to `profiles.id`.
-- `role`: granted role enum `verifier | moderator | curator | admin`.
+- `role`: granted role enum `verifier | moderator | curator | admin | official`.
 - `granted_at`: when the role was granted.
 
 For now, roles are granted directly by an admin inserting the `user_roles` row. A self-service application flow is deferred for later; see [Role applications](#role-applications) under Not Yet Implemented.
@@ -48,6 +48,7 @@ A guide base is the graph node. It stores no content of its own, as all content 
 - `slug`: stable URL identifier. Derived from the first published revision's title and frozen at first publish, unique across all guide bases; never auto-changed by later title edits, exactly like `guides.slug`.
 - `knowledge_type`: `theoretical` (a grand explanation of something we can observe) or `practical` (a route to a specific, well-defined goal). Determines how the topic is structured and what its guides are called: `practical` guides display as **methods**, `theoretical` guides as **alternatives**.
 - `status`: draft lifecycle state (see enum below).
+- `is_official`: boolean, default `false`. `true` marks a BLUE-authored topic. An official base does not allow variants, and its publish and edit reviews go to admins rather than verifiers.
 - `created_at`: row creation time.
 - `updated_at`: last update time.
 - `forked_from_guide_base_id`: nullable self-reference. When a cross-subject conflict resolves into a **spin-off** (see `overall-system.md`), the guide base forks into a subject-specific version. This makes the spin-off an explicit, governed exception to "one canonical guide base per topic" instead of looking like an accidental duplicate. In practice, there will be a message/indicator saying something like "forked from {original-title}".
@@ -357,7 +358,7 @@ Verifier gates, post-publish re-reviews, disputes, and appeals all share the sam
 The item being reviewed.
 
 - `id`: primary key of the case.
-- `case_type`: what work the case represents: `guide_publish` | `guide_edit` | `dispute` | `appeal` | `re_review`.
+- `case_type`: what work the case represents: `guide_publish` | `guide_edit` | `official_publish` | `official_edit` | `dispute` | `appeal` | `re_review`.
 - `status`: lifecycle state: `pending` | `in_review` | `approved` | `rejected`.
 - `created_by`: the user who opened the case (author for publish/edit/appeal, filer for dispute).
 - `created_at`: when the case was created.
@@ -366,7 +367,7 @@ The item being reviewed.
 
 `review_panels`:
 
-An odd-numbered random group of panelists assembled to decide a case, drawn from the pool that matches the case type: **verifiers** for `guide_publish`/`guide_edit`, **moderators** for `re_review`/`dispute`/`appeal`.
+An odd-numbered random group of panelists assembled to decide a case, drawn from the pool that matches the case type: **verifiers** for `guide_publish`/`guide_edit`, **moderators** for `re_review`/`dispute`/`appeal`, **admins** for `official_publish`/`official_edit`.
 
 - `id`: primary key of the panel.
 - `case_id`: the case this panel decides (FK to `review_cases`). One case may have many panels.
@@ -381,7 +382,7 @@ Panelists seated on a panel. One row per seat per panel. Tracks each seat's life
 
 - `id`: primary key of the seat.
 - `panel_id`: the panel this seat belongs to (FK to `review_panels`).
-- `member_id`: the panelist (verifier or moderator) holding the seat (FK to `profiles.id`). 
+- `member_id`: the panelist (verifier, moderator, or admin) holding the seat (FK to `profiles.id`). 
 - `status`: seat lifecycle state (see enum below).
 - `assigned_at`: when the panelist was drawn onto the panel. The time limit counts from here.
 
@@ -417,7 +418,7 @@ A `rejected` decision must have at least one row here; an `approved` has none.
 
 Each attaches type-specific data to a `review_cases` row. `case_id` is both primary key and FK to `review_cases` → one satellite row per case.
 
-`guide_review_cases` (for `guide_publish`, `guide_edit`):
+`guide_review_cases` (for `guide_publish`, `guide_edit`, `official_publish`, `official_edit`):
 
 - `case_id`: PK and FK to `review_cases`.
 - `guide_revision_id`: FK to `guide_revisions` — the exact guide revision under review. All content lives in one revision table now, so this is a single FK (no polymorphic split). It pins the panel to the exact snapshot it judged, so the decision stays attached to specific content after later edits.

--- a/packages/schemas/src/guides/responses.ts
+++ b/packages/schemas/src/guides/responses.ts
@@ -52,6 +52,7 @@ export const guideListItemSchema = z.object({
   author: z.string().nullable(),
   duration_minutes: z.number().int(),
   tags: z.array(subjectReferenceSchema),
+  is_official: z.boolean(),
 });
 
 export type Guide = z.infer<typeof guideSchema>;

--- a/packages/schemas/src/guides/responses.ts
+++ b/packages/schemas/src/guides/responses.ts
@@ -10,6 +10,7 @@ export const guideSchema = z.object({
   variant_slug: z.string().nullable(),
   title: z.string(),
   author: z.string(),
+  knowledge_type: knowledgeTypeSchema,
   summary: z.string().nullable(),
   body: z.string().nullable(),
   duration_minutes: z.number().int(),

--- a/packages/schemas/src/guides/responses.ts
+++ b/packages/schemas/src/guides/responses.ts
@@ -16,6 +16,7 @@ export const guideSchema = z.object({
   created_at: z.iso.datetime(),
   tags: z.array(subjectReferenceSchema),
   prerequisites: z.array(guideReferenceSchema),
+  is_official: z.boolean(),
 });
 
 export const walkthroughSchema = z.object({

--- a/packages/schemas/src/review/enums.ts
+++ b/packages/schemas/src/review/enums.ts
@@ -7,7 +7,12 @@ export const reviewCaseStatusSchema = z.enum([
   "rejected",
 ]);
 
-export const reviewCaseTypeSchema = z.enum(["guide_publish", "guide_edit"]);
+export const reviewCaseTypeSchema = z.enum([
+  "guide_publish",
+  "guide_edit",
+  "official_publish",
+  "official_edit",
+]);
 
 export const reviewOutcomeSchema = z.enum(["approved", "rejected"]);
 

--- a/supabase/migrations/20260817120000_official_guide_enums.sql
+++ b/supabase/migrations/20260817120000_official_guide_enums.sql
@@ -1,0 +1,5 @@
+alter type public.app_role add value 'official';
+alter type public.case_type add value 'official_publish';
+alter type public.case_type add value 'official_edit';
+alter table public.guide_bases
+  add column is_official boolean not null default false;

--- a/supabase/migrations/20260817120100_official_guide_authoring.sql
+++ b/supabase/migrations/20260817120100_official_guide_authoring.sql
@@ -1,0 +1,174 @@
+-- Same as 20260623130000_drop_revision_number.sql except the base now records
+-- whether its creator holds the official role.
+create or replace function public.create_guide(
+  p_title text default null,
+  p_knowledge_type public.knowledge_type default 'theoretical',
+  p_summary text default null,
+  p_body text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_base_id uuid := gen_random_uuid();
+  v_guide_id uuid := gen_random_uuid();
+  v_revision_id uuid := gen_random_uuid();
+begin
+  -- knowledge_type defaults to theoretical and is changeable
+  -- in the editor while the topic is a draft.
+  insert into public.guide_bases (id, knowledge_type, status, is_official)
+    values (v_base_id, p_knowledge_type, 'draft', public.has_role('official'));
+
+  insert into public.guides (id, guide_base_id, author_id, status)
+    values (v_guide_id, v_base_id, auth.uid(), 'draft');
+
+  insert into public.guide_revisions
+    (id, guide_id, title, summary, body, author_id, status)
+    values (v_revision_id, v_guide_id, p_title, p_summary, p_body, auth.uid(), 'draft');
+
+  -- Return the draft revision id so the client routes straight to its editor.
+  return v_revision_id;
+end;
+$$;
+
+grant execute on function public.create_guide(
+  text, public.knowledge_type, text, text
+) to authenticated;
+
+-- Checks if guide base is official, which gates if a variant can be created for it.
+create or replace function public.create_variant(
+  p_guide_base_id uuid,
+  p_title text default null,
+  p_summary text default null,
+  p_body text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_guide_id uuid := gen_random_uuid();
+  v_revision_id uuid := gen_random_uuid();
+begin
+  if exists (
+    select 1 from public.guide_bases
+    where id = p_guide_base_id and is_official
+  ) then
+    raise exception 'Official guides do not take variants'
+      using errcode = 'check_violation';
+  end if;
+
+  insert into public.guides (id, guide_base_id, author_id, status)
+    values (v_guide_id, p_guide_base_id, auth.uid(), 'draft');
+
+  insert into public.guide_revisions
+    (id, guide_id, title, summary, body, author_id, status)
+    values (v_revision_id, v_guide_id, p_title, p_summary, p_body, auth.uid(), 'draft');
+
+  return v_revision_id;
+end;
+$$;
+
+grant execute on function public.create_variant(
+  uuid, text, text, text
+) to authenticated;
+
+create or replace function public.reject_official_variant()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if exists (
+    select 1 from public.guide_bases b
+    where b.id = new.guide_base_id and b.is_official
+  ) and exists (
+    select 1 from public.guides g
+    where g.guide_base_id = new.guide_base_id and g.id <> new.id
+  ) then
+    raise exception 'Official guides do not take variants'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+revoke execute on function public.reject_official_variant() from public;
+
+create trigger guides_reject_official_variant
+  before insert on public.guides
+  for each row
+  execute function public.reject_official_variant();
+
+-- Same as 20260716140000_guide_contribution_flow.sql except an official base
+-- opens the admin-decided case types.
+create or replace function public.submit_guide_revision(p_revision_id uuid)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_guide_id uuid;
+  v_current_revision_id uuid;
+  v_is_official boolean;
+  v_case_type public.case_type;
+  v_case_id uuid;
+  v_title text;
+  v_summary text;
+  v_body text;
+  v_tag_count integer;
+begin
+  select title, summary, body into v_title, v_summary, v_body
+    from public.guide_revisions
+    where id = p_revision_id and status = 'draft';
+
+  if not found then
+    raise exception 'Revision not found or not an editable draft'
+      using errcode = 'no_data_found';
+  end if;
+
+  select count(*) into v_tag_count
+    from public.guide_revision_subjects
+    where guide_revision_id = p_revision_id;
+
+  if coalesce(btrim(v_title), '') = ''
+     or coalesce(btrim(v_summary), '') = ''
+     or coalesce(btrim(v_body), '') = ''
+     or v_tag_count = 0 then
+    raise exception 'Revision is missing a title, summary, body, or tag'
+      using errcode = 'check_violation';
+  end if;
+
+  update public.guide_revisions
+    set status = 'submitted'
+    where id = p_revision_id
+    returning guide_id into v_guide_id;
+
+  select g.current_revision_id, b.is_official
+    into v_current_revision_id, v_is_official
+    from public.guides g
+    join public.guide_bases b on b.id = g.guide_base_id
+    where g.id = v_guide_id;
+
+  v_case_type := case
+    when v_is_official and v_current_revision_id is null then 'official_publish'
+    when v_is_official then 'official_edit'
+    when v_current_revision_id is null then 'guide_publish'
+    else 'guide_edit'
+  end;
+
+  insert into public.review_cases (case_type, created_by)
+    values (v_case_type, auth.uid())
+    returning id into v_case_id;
+
+  insert into public.guide_review_cases (case_id, guide_revision_id)
+    values (v_case_id, p_revision_id);
+
+  return v_case_id;
+end;
+$$;

--- a/supabase/migrations/20260817120200_official_review_panels.sql
+++ b/supabase/migrations/20260817120200_official_review_panels.sql
@@ -28,6 +28,29 @@ $$;
 revoke execute on function public.eligible_panel_admins(uuid, uuid) from public;
 grant execute on function public.eligible_panel_admins(uuid, uuid) to service_role;
 
+-- Same as 20260805120000_review_time_limits.sql except exclude official seats because they
+-- never expire.
+create or replace function public.set_panel_member_expires_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.expires_at is null then
+    select coalesce(new.assigned_at, now()) + coalesce(rc.time_limit, interval '2 days')
+      into new.expires_at
+      from public.review_panels rp
+      join public.review_cases rc on rc.id = rp.case_id
+      where rp.id = new.panel_id
+        and rc.case_type not in ('official_publish', 'official_edit');
+  end if;
+  return new;
+end;
+$$;
+
+revoke execute on function public.set_panel_member_expires_at() from public;
+
 -- Same as 20260805120000_review_time_limits.sql for the verifier case types, but for an
 -- official case, it seats every eligible admin instead of drawing a random panel,
 -- so target_seat_count records how many were seated and carries no odd size check.
@@ -119,8 +142,8 @@ $$;
 revoke execute on function public.assemble_review_panel(uuid, integer) from public;
 grant execute on function public.assemble_review_panel(uuid, integer) to service_role;
 
--- Same as 20260716140000_guide_contribution_flow.sql except official cases need
--- two matching votes rather than a normal majority vote from the seats.
+-- Same as 20260802120100_resolve_claimed_todos_on_publish.sql except official
+-- cases need two matching votes rather than a normal majority vote from the seats.
 create or replace function public.close_review_panel(p_case_id uuid)
 returns void
 language plpgsql
@@ -138,10 +161,12 @@ declare
   v_revision_id uuid;
   v_guide_id uuid;
   v_base_id uuid;
+  v_base_slug text;
   v_title text;
   v_slug_base text;
   v_slug text;
   v_suffix integer;
+  v_subject record;
 begin
   select rp.id, rp.target_seat_count, rc.case_type
     into v_panel_id, v_target, v_case_type
@@ -187,11 +212,12 @@ begin
     return;
   end if;
 
-  select grc.guide_revision_id, gr.guide_id, g.guide_base_id, gr.title
-    into v_revision_id, v_guide_id, v_base_id, v_title
+  select grc.guide_revision_id, gr.guide_id, g.guide_base_id, gr.title, b.slug
+    into v_revision_id, v_guide_id, v_base_id, v_title, v_base_slug
     from public.guide_review_cases grc
     join public.guide_revisions gr on gr.id = grc.guide_revision_id
     join public.guides g on g.id = gr.guide_id
+    join public.guide_bases b on b.id = g.guide_base_id
     where grc.case_id = p_case_id;
 
   update public.guide_revisions
@@ -221,15 +247,64 @@ begin
           slug = coalesce(slug, v_slug)
       where id = v_guide_id;
 
+    if v_base_slug is null then
+      v_slug := v_slug_base;
+      v_suffix := 1;
+      while exists (
+        select 1 from public.guide_bases where slug = v_slug and id <> v_base_id
+      ) loop
+        v_suffix := v_suffix + 1;
+        v_slug := v_slug_base || '-' || v_suffix;
+      end loop;
+      v_base_slug := v_slug;
+    end if;
+
     update public.guide_bases
       set status = 'published',
-          canonical_guide_id = coalesce(canonical_guide_id, v_guide_id)
+          canonical_guide_id = coalesce(canonical_guide_id, v_guide_id),
+          slug = coalesce(slug, v_base_slug)
       where id = v_base_id;
+
+    update public.todo_prerequisites
+      set status = 'resolved',
+          resolved_guide_base_id = v_base_id
+      where status = 'open'
+        and id in (
+          select tc.todo_id
+          from public.todo_claims tc
+          where tc.guide_base_id = v_base_id
+        );
   else
     update public.guides
       set current_revision_id = v_revision_id
       where id = v_guide_id;
   end if;
+
+  for v_subject in
+    select s.id, s.name
+      from public.subjects s
+      join public.guide_revision_subjects grs on grs.subject_id = s.id
+      where grs.guide_revision_id = v_revision_id
+        and s.slug is null
+      for update of s
+  loop
+    v_slug_base := lower(
+      trim(both '-' from regexp_replace(coalesce(v_subject.name, ''), '[^a-zA-Z0-9]+', '-', 'g'))
+    );
+    if v_slug_base = '' then
+      v_slug_base := 'subject';
+    end if;
+    v_slug := v_slug_base;
+    v_suffix := 1;
+    while exists (
+      select 1 from public.subjects where slug = v_slug
+    ) loop
+      v_suffix := v_suffix + 1;
+      v_slug := v_slug_base || '-' || v_suffix;
+    end loop;
+
+    update public.subjects set slug = v_slug where id = v_subject.id;
+  end loop;
 
   update public.subjects s
     set status = 'published'
@@ -241,90 +316,3 @@ end;
 $$;
 
 grant execute on function public.close_review_panel(uuid) to authenticated, service_role;
-
--- Same as 20260805120000_review_time_limits.sql except official panels sit out
--- the sweep.
-create or replace function public.sweep_expired_review_seats()
-returns jsonb
-language plpgsql
-security definer
-set search_path = ''
-as $$
-declare
-  v_lock_acquired boolean;
-  v_seat record;
-  v_panel record;
-  v_new_member record;
-  v_replaced_count integer := 0;
-  v_assigned_count integer := 0;
-begin
-  v_lock_acquired := pg_try_advisory_xact_lock(hashtext('sweep_expired_review_seats'));
-  if not v_lock_acquired then
-    return jsonb_build_object(
-      'replaced_count', 0,
-      'assigned_count', 0,
-      'skipped', true
-    );
-  end if;
-
-  for v_seat in (
-    select pm.id as seat_id
-      from public.panel_members pm
-      join public.review_panels rp on rp.id = pm.panel_id
-      join public.review_cases rc on rc.id = rp.case_id
-      where rp.closed_at is null
-        and rc.status = 'in_review'
-        and rc.case_type not in ('official_publish', 'official_edit')
-        and pm.status = 'assigned'
-        and now() > pm.expires_at
-      order by pm.expires_at asc
-      limit 100
-      for update of pm skip locked
-  ) loop
-    update public.panel_members
-      set status = 'replaced'
-      where id = v_seat.seat_id;
-    v_replaced_count := v_replaced_count + 1;
-  end loop;
-
-  for v_panel in (
-    select
-      rp.id as panel_id,
-      rc.created_by,
-      rp.target_seat_count - count(pm.id) filter (
-        where pm.status in ('assigned', 'completed')
-      ) as needed
-      from public.review_panels rp
-      join public.review_cases rc on rc.id = rp.case_id
-      left join public.panel_members pm on pm.panel_id = rp.id
-      where rp.closed_at is null
-        and rc.status = 'in_review'
-        and rc.case_type not in ('official_publish', 'official_edit')
-      group by rp.id, rp.target_seat_count, rc.created_by
-      having rp.target_seat_count - count(pm.id) filter (
-        where pm.status in ('assigned', 'completed')
-      ) > 0
-      limit 100
-  ) loop
-    for v_new_member in (
-      select id
-        from public.eligible_panel_verifiers(v_panel.created_by, v_panel.panel_id)
-        order by random()
-        limit v_panel.needed
-    ) loop
-      insert into public.panel_members (panel_id, member_id, status, assigned_at)
-        values (v_panel.panel_id, v_new_member.id, 'assigned', now());
-      v_assigned_count := v_assigned_count + 1;
-    end loop;
-  end loop;
-
-  return jsonb_build_object(
-    'replaced_count', v_replaced_count,
-    'assigned_count', v_assigned_count,
-    'skipped', false
-  );
-end;
-$$;
-
-revoke execute on function public.sweep_expired_review_seats() from public;
-grant execute on function public.sweep_expired_review_seats() to service_role;

--- a/supabase/migrations/20260817120200_official_review_panels.sql
+++ b/supabase/migrations/20260817120200_official_review_panels.sql
@@ -1,3 +1,8 @@
+-- An official panel seats every eligible admin, so its size can be even.
+-- assemble_review_panel still forces an odd draw for the verifier case types.
+alter table public.review_panels
+  drop constraint if exists review_panels_seat_count_odd;
+
 create or replace function public.eligible_panel_admins(
   p_created_by uuid,
   p_panel_id uuid default null

--- a/supabase/migrations/20260817120200_official_review_panels.sql
+++ b/supabase/migrations/20260817120200_official_review_panels.sql
@@ -1,0 +1,330 @@
+create or replace function public.eligible_panel_admins(
+  p_created_by uuid,
+  p_panel_id uuid default null
+)
+returns table (id uuid)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select p.id
+    from public.user_roles ur
+    join public.profiles p on p.id = ur.user_id
+    where ur.role = 'admin'
+      and p.is_suspended = false
+      and p.id is distinct from p_created_by
+      and (
+        p_panel_id is null
+        or not exists (
+          select 1
+            from public.panel_members pm
+            where pm.panel_id = p_panel_id
+              and pm.member_id = p.id
+        )
+      );
+$$;
+
+revoke execute on function public.eligible_panel_admins(uuid, uuid) from public;
+grant execute on function public.eligible_panel_admins(uuid, uuid) to service_role;
+
+-- Same as 20260805120000_review_time_limits.sql for the verifier case types, but for an
+-- official case, it seats every eligible admin instead of drawing a random panel,
+-- so target_seat_count records how many were seated and carries no odd size check.
+create or replace function public.assemble_review_panel(
+  p_case_id uuid,
+  p_policy_default integer
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status public.case_status;
+  v_case_type public.case_type;
+  v_created_by uuid;
+  v_pool_size integer;
+  v_target integer;
+  v_panel_id uuid;
+begin
+  select status, case_type, created_by
+    into v_status, v_case_type, v_created_by
+    from public.review_cases
+    where id = p_case_id
+    for update;
+
+  if not found then
+    raise exception 'Review case not found' using errcode = 'no_data_found';
+  end if;
+
+  if v_status <> 'pending' then
+    return null;
+  end if;
+  if exists (
+    select 1 from public.review_panels
+    where case_id = p_case_id and closed_at is null
+  ) then
+    return null;
+  end if;
+
+  if v_case_type in ('official_publish', 'official_edit') then
+    select count(*)
+      into v_pool_size
+      from public.eligible_panel_admins(v_created_by);
+
+    if v_pool_size < 2 then
+      return null;
+    end if;
+
+    insert into public.review_panels (case_id, target_seat_count)
+      values (p_case_id, v_pool_size)
+      returning id into v_panel_id;
+
+    insert into public.panel_members (panel_id, member_id)
+    select v_panel_id, id
+      from public.eligible_panel_admins(v_created_by);
+  else
+    select count(*)
+      into v_pool_size
+      from public.eligible_panel_verifiers(v_created_by);
+
+    v_target := least(p_policy_default, v_pool_size);
+    if v_target % 2 = 0 then
+      v_target := v_target - 1;
+    end if;
+    if v_target < 3 then
+      return null;
+    end if;
+
+    insert into public.review_panels (case_id, target_seat_count)
+      values (p_case_id, v_target)
+      returning id into v_panel_id;
+
+    insert into public.panel_members (panel_id, member_id)
+    select v_panel_id, id
+      from public.eligible_panel_verifiers(v_created_by)
+      order by random()
+      limit v_target;
+  end if;
+
+  update public.review_cases
+    set status = 'in_review'
+    where id = p_case_id;
+
+  return v_panel_id;
+end;
+$$;
+
+revoke execute on function public.assemble_review_panel(uuid, integer) from public;
+grant execute on function public.assemble_review_panel(uuid, integer) to service_role;
+
+-- Same as 20260716140000_guide_contribution_flow.sql except official cases need
+-- two matching votes rather than a normal majority vote from the seats.
+create or replace function public.close_review_panel(p_case_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_panel_id uuid;
+  v_target integer;
+  v_case_type public.case_type;
+  v_threshold integer;
+  v_approve integer;
+  v_reject integer;
+  v_outcome public.review_outcome;
+  v_revision_id uuid;
+  v_guide_id uuid;
+  v_base_id uuid;
+  v_title text;
+  v_slug_base text;
+  v_slug text;
+  v_suffix integer;
+begin
+  select rp.id, rp.target_seat_count, rc.case_type
+    into v_panel_id, v_target, v_case_type
+    from public.review_panels rp
+    join public.review_cases rc on rc.id = rp.case_id
+    where rp.case_id = p_case_id and rp.closed_at is null
+    for update of rp;
+
+  if not found then
+    return;
+  end if;
+
+  v_threshold := case
+    when v_case_type in ('official_publish', 'official_edit') then 2
+    else v_target / 2 + 1
+  end;
+
+  select
+    count(*) filter (where d.decision = 'approved'),
+    count(*) filter (where d.decision = 'rejected')
+    into v_approve, v_reject
+    from public.panel_members pm
+    join public.review_decisions d on d.panel_member_id = pm.id
+    where pm.panel_id = v_panel_id;
+
+  if v_approve >= v_threshold then
+    v_outcome := 'approved';
+  elsif v_reject >= v_threshold then
+    v_outcome := 'rejected';
+  else
+    return;
+  end if;
+
+  update public.review_panels
+    set outcome = v_outcome, closed_at = now()
+    where id = v_panel_id;
+
+  update public.review_cases
+    set status = v_outcome::text::public.case_status
+    where id = p_case_id;
+
+  if v_outcome <> 'approved' then
+    return;
+  end if;
+
+  select grc.guide_revision_id, gr.guide_id, g.guide_base_id, gr.title
+    into v_revision_id, v_guide_id, v_base_id, v_title
+    from public.guide_review_cases grc
+    join public.guide_revisions gr on gr.id = grc.guide_revision_id
+    join public.guides g on g.id = gr.guide_id
+    where grc.case_id = p_case_id;
+
+  update public.guide_revisions
+    set approved_at = now()
+    where id = v_revision_id;
+
+  if v_case_type in ('guide_publish', 'official_publish') then
+    v_slug_base := lower(
+      trim(both '-' from regexp_replace(coalesce(v_title, ''), '[^a-zA-Z0-9]+', '-', 'g'))
+    );
+    if v_slug_base = '' then
+      v_slug_base := 'guide';
+    end if;
+    v_slug := v_slug_base;
+    v_suffix := 1;
+    while exists (
+      select 1 from public.guides
+      where guide_base_id = v_base_id and slug = v_slug and id <> v_guide_id
+    ) loop
+      v_suffix := v_suffix + 1;
+      v_slug := v_slug_base || '-' || v_suffix;
+    end loop;
+
+    update public.guides
+      set current_revision_id = v_revision_id,
+          status = 'published',
+          slug = coalesce(slug, v_slug)
+      where id = v_guide_id;
+
+    update public.guide_bases
+      set status = 'published',
+          canonical_guide_id = coalesce(canonical_guide_id, v_guide_id)
+      where id = v_base_id;
+  else
+    update public.guides
+      set current_revision_id = v_revision_id
+      where id = v_guide_id;
+  end if;
+
+  update public.subjects s
+    set status = 'published'
+    from public.guide_revision_subjects grs
+    where grs.guide_revision_id = v_revision_id
+      and grs.subject_id = s.id
+      and s.status <> 'published';
+end;
+$$;
+
+grant execute on function public.close_review_panel(uuid) to authenticated, service_role;
+
+-- Same as 20260805120000_review_time_limits.sql except official panels sit out
+-- the sweep.
+create or replace function public.sweep_expired_review_seats()
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_lock_acquired boolean;
+  v_seat record;
+  v_panel record;
+  v_new_member record;
+  v_replaced_count integer := 0;
+  v_assigned_count integer := 0;
+begin
+  v_lock_acquired := pg_try_advisory_xact_lock(hashtext('sweep_expired_review_seats'));
+  if not v_lock_acquired then
+    return jsonb_build_object(
+      'replaced_count', 0,
+      'assigned_count', 0,
+      'skipped', true
+    );
+  end if;
+
+  for v_seat in (
+    select pm.id as seat_id
+      from public.panel_members pm
+      join public.review_panels rp on rp.id = pm.panel_id
+      join public.review_cases rc on rc.id = rp.case_id
+      where rp.closed_at is null
+        and rc.status = 'in_review'
+        and rc.case_type not in ('official_publish', 'official_edit')
+        and pm.status = 'assigned'
+        and now() > pm.expires_at
+      order by pm.expires_at asc
+      limit 100
+      for update of pm skip locked
+  ) loop
+    update public.panel_members
+      set status = 'replaced'
+      where id = v_seat.seat_id;
+    v_replaced_count := v_replaced_count + 1;
+  end loop;
+
+  for v_panel in (
+    select
+      rp.id as panel_id,
+      rc.created_by,
+      rp.target_seat_count - count(pm.id) filter (
+        where pm.status in ('assigned', 'completed')
+      ) as needed
+      from public.review_panels rp
+      join public.review_cases rc on rc.id = rp.case_id
+      left join public.panel_members pm on pm.panel_id = rp.id
+      where rp.closed_at is null
+        and rc.status = 'in_review'
+        and rc.case_type not in ('official_publish', 'official_edit')
+      group by rp.id, rp.target_seat_count, rc.created_by
+      having rp.target_seat_count - count(pm.id) filter (
+        where pm.status in ('assigned', 'completed')
+      ) > 0
+      limit 100
+  ) loop
+    for v_new_member in (
+      select id
+        from public.eligible_panel_verifiers(v_panel.created_by, v_panel.panel_id)
+        order by random()
+        limit v_panel.needed
+    ) loop
+      insert into public.panel_members (panel_id, member_id, status, assigned_at)
+        values (v_panel.panel_id, v_new_member.id, 'assigned', now());
+      v_assigned_count := v_assigned_count + 1;
+    end loop;
+  end loop;
+
+  return jsonb_build_object(
+    'replaced_count', v_replaced_count,
+    'assigned_count', v_assigned_count,
+    'skipped', false
+  );
+end;
+$$;
+
+revoke execute on function public.sweep_expired_review_seats() from public;
+grant execute on function public.sweep_expired_review_seats() to service_role;

--- a/supabase/migrations/20260817120300_add_official_column_to_published_guides_view.sql
+++ b/supabase/migrations/20260817120300_add_official_column_to_published_guides_view.sql
@@ -1,0 +1,24 @@
+create or replace view public.published_guides with (security_invoker = on) as
+select
+  gb.id,
+  gb.slug as base_slug,
+  gb.knowledge_type,
+  gb.status,
+  gb.created_at,
+  g.id as guide_id,
+  g.slug as guide_slug,
+  g.author_id,
+  r.id as revision_id,
+  r.title,
+  r.summary,
+  r.word_count,
+  (
+    select coalesce(array_agg(grs.subject_id), '{}'::uuid[])
+    from public.guide_revision_subjects grs
+    where grs.guide_revision_id = r.id
+  ) as subject_ids,
+  gb.is_official
+from public.guide_bases gb
+join public.guides g on g.id = gb.canonical_guide_id
+join public.guide_revisions r on r.id = g.current_revision_id
+where gb.status = 'published';


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Added official guides where accounts with the `official` role submit their guides to the admins, who can review and approve it. Official guides cannot have variants, but anyone can submit a revision, which is also sent to only admins and not verifiers.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
