### PR TITLE
fix: correct 'prerequsite' to 'prerequisite' typo in GuideDetails.tsx

### DIFF
--- a/app/src/components/contribute/steps/GuideDetails.tsx
+++ b/app/src/components/contribute/steps/GuideDetails.tsx
@@ -345,7 +345,7 @@ export const GuideDetails = ({
             <Field className="space-y-2">
               <div className="space-y-1">
                 <FieldLabel className="font-mono tracking-[0.08em] uppercase">
-                  Prerequsite Guides
+                  Prerequisite Guides
                 </FieldLabel>
                 <FieldDescription className="text-xs">
                   Existing guides a reader should understand first.
@@ -376,7 +376,7 @@ export const GuideDetails = ({
             <Field className="space-y-2">
               <div className="space-y-1">
                 <FieldLabel className="font-mono tracking-[0.08em] uppercase">
-                  Todo Prerequsite Guides
+                  Todo Prerequisite Guides
                 </FieldLabel>
                 <FieldDescription className="text-xs">
                   Note missing prerequisite guides that don't exist yet.
@@ -388,7 +388,7 @@ export const GuideDetails = ({
                   id="todo-prereqs"
                   type="text"
                   maxLength={50}
-                  placeholder="Enter title of missing prerequsite guide."
+                  placeholder="Enter title of missing prerequisite guide."
                   className="h-10 rounded-md"
                   value={todoPrereq.title}
                   onChange={(e) =>
@@ -403,7 +403,7 @@ export const GuideDetails = ({
                   id="todo-prereq-summary"
                   type="text"
                   maxLength={500}
-                  placeholder="Enter summary of missing prerequsite guide."
+                  placeholder="Enter summary of missing prerequisite guide."
                   className="h-10 rounded-md"
                   value={todoPrereq.summary}
                   onChange={(e) =>


### PR DESCRIPTION
## Summary
Fix 4 instances of `prerequsite` -> `prerequisite` typo in `app/src/components/contribute/steps/GuideDetails.tsx`:

1. Line 348: FieldLabel `Prerequsite Guides` -> `Prerequisite Guides`
2. Line 379: FieldLabel `Todo Prerequsite Guides` -> `Todo Prerequisite Guides`
3. Line 391: placeholder `missing prerequsite guide.` -> `missing prerequisite guide.`
4. Line 406: placeholder `missing prerequsite guide.` -> `missing prerequisite guide.`

Fixes bluelearn-org/bluelearn#334

## Type of change
Bug
<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behaviour changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
