### PR TITLE
fix(app): show correct dark mode toggle state on first load

### DIFF
--- a/app/src/lib/__tests__/themeProvider.test.tsx
+++ b/app/src/lib/__tests__/themeProvider.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider, useTheme } from "@/lib/themeProvider";
+
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+};
+
+const mockPrefersDark = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+    writable: true,
+    configurable: true,
+  });
+};
+
+/**
+ * Records the theme seen on every render so we can assert on the *first* one,
+ * which is the render that has to match the server-generated markup.
+ */
+function renderThemes() {
+  const themes: Array<string> = [];
+  let setTheme: (theme: "light" | "dark") => void = () => {};
+
+  function Probe() {
+    const ctx = useTheme();
+    themes.push(ctx.theme);
+    setTheme = ctx.setTheme;
+    return null;
+  }
+
+  render(
+    <ThemeProvider>
+      <Probe />
+    </ThemeProvider>
+  );
+
+  return { themes, setTheme: (theme: "light" | "dark") => setTheme(theme) };
+}
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: createLocalStorageMock(),
+      writable: true,
+      configurable: true,
+    });
+    document.documentElement.classList.remove("dark");
+    mockPrefersDark(false);
+  });
+
+  // Regression test for #327: the footer toggle rendered "off" on a dark-mode
+  // load because the provider seeded its state from the DOM. That disagreed
+  // with the server markup, and React does not repair mismatched attributes
+  // while hydrating.
+  it("renders light on the first pass so it matches the server markup", () => {
+    localStorage.setItem("theme", "dark");
+    document.documentElement.classList.add("dark");
+
+    const { themes } = renderThemes();
+
+    expect(themes[0]).toBe("light");
+  });
+
+  it("adopts the stored theme once effects have run", () => {
+    localStorage.setItem("theme", "dark");
+    document.documentElement.classList.add("dark");
+
+    const { themes } = renderThemes();
+
+    expect(themes.at(-1)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("falls back to the system preference when nothing is stored", () => {
+    mockPrefersDark(true);
+
+    const { themes } = renderThemes();
+
+    expect(themes.at(-1)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("stays light when neither storage nor the system asks for dark", () => {
+    const { themes } = renderThemes();
+
+    expect(themes.at(-1)).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("ignores an unrecognised stored value", () => {
+    localStorage.setItem("theme", "sepia");
+    mockPrefersDark(true);
+
+    const { themes } = renderThemes();
+
+    expect(themes.at(-1)).toBe("dark");
+  });
+
+  it("persists and applies the theme when it is changed", () => {
+    localStorage.setItem("theme", "dark");
+    document.documentElement.classList.add("dark");
+
+    const { setTheme } = renderThemes();
+
+    act(() => setTheme("light"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+  });
+});

--- a/app/src/lib/themeProvider.tsx
+++ b/app/src/lib/themeProvider.tsx
@@ -11,28 +11,37 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | null>(null);
 
-export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    if (typeof document === "undefined") return "light";
+const STORAGE_KEY = "theme";
 
-    return document.documentElement.classList.contains("dark")
-      ? "dark"
-      : "light";
-  });
+/**
+ * The theme the document is *actually* rendering with. The inline script in
+ * `__root.tsx` resolves this same value and applies the `dark` class before
+ * first paint, so this only re-derives it for React's benefit. Client-only —
+ * it touches `localStorage` and `matchMedia`.
+ */
+function resolveTheme(): Theme {
+  const saved = localStorage.getItem(STORAGE_KEY);
+
+  if (saved === "dark" || saved === "light") {
+    return saved;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  // The server has no way to know the visitor's theme, so it always renders
+  // the "light" markup. The first client render has to agree with that markup:
+  // React does not repair mismatched attributes while hydrating, so seeding
+  // this from the DOM left theme-dependent controls stuck on their
+  // server-rendered state (#327). The real theme is applied in the effect
+  // below, after hydration, where a genuine state change can re-render them.
+  const [theme, setThemeState] = useState<Theme>("light");
 
   useEffect(() => {
-    const saved = localStorage.getItem("theme") as Theme | null;
-
-    if (saved) {
-      setTheme(saved);
-      return;
-    }
-
-    const prefersDark = window.matchMedia(
-      "(prefers-color-scheme: dark)"
-    ).matches;
-
-    setTheme(prefersDark ? "dark" : "light");
+    setTheme(resolveTheme());
   }, []);
 
   function setTheme(newTheme: Theme) {
@@ -40,7 +49,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
     document.documentElement.classList.toggle("dark", newTheme === "dark");
 
-    localStorage.setItem("theme", newTheme);
+    localStorage.setItem(STORAGE_KEY, newTheme);
   }
 
   return (

--- a/app/src/lib/themeProvider.tsx
+++ b/app/src/lib/themeProvider.tsx
@@ -13,12 +13,7 @@ const ThemeContext = createContext<ThemeContextType | null>(null);
 
 const STORAGE_KEY = "theme";
 
-/**
- * The theme the document is *actually* rendering with. The inline script in
- * `__root.tsx` resolves this same value and applies the `dark` class before
- * first paint, so this only re-derives it for React's benefit. Client-only —
- * it touches `localStorage` and `matchMedia`.
- */
+// gets theme from client - set theme before the page first renders
 function resolveTheme(): Theme {
   const saved = localStorage.getItem(STORAGE_KEY);
 
@@ -32,12 +27,7 @@ function resolveTheme(): Theme {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  // The server has no way to know the visitor's theme, so it always renders
-  // the "light" markup. The first client render has to agree with that markup:
-  // React does not repair mismatched attributes while hydrating, so seeding
-  // this from the DOM left theme-dependent controls stuck on their
-  // server-rendered state (#327). The real theme is applied in the effect
-  // below, after hydration, where a genuine state change can re-render them.
+  // keeps client render consistent with server light markup - avoid hydration mismatch then applies the actual theme after hydration
   const [theme, setThemeState] = useState<Theme>("light");
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #327 — the footer dark mode toggle renders "off" on a dark-mode load, and only starts telling the truth after the user toggles it off and back on.

**Why it happens**

`ThemeProvider` seeded its state by reading the `dark` class off `documentElement`. On the server `document` doesn't exist, so SSR always fell through to `"light"` and emitted the switch as `data-state="unchecked" aria-checked="false"`. On the client the initializer read the class that the inline script in `__root.tsx` had already applied and returned `"dark"` instead — so the very first client render disagreed with the server markup.

React does not repair mismatched attributes while hydrating. It says so itself in the console on `main`:

> A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. **This won't be patched up.**
> ```
> <button role="switch"
> +  aria-checked={true}      data-state="checked"     (what the client wanted)
> -  aria-checked="false"     data-state="unchecked"   (what the server sent, and what stays)
> ```

The mount effect couldn't rescue it either. It called `setTheme("dark")` while the state was *already* `"dark"`, so React bailed out of the update and never re-rendered — leaving the stale attributes in the DOM. Only a real state transition could rewrite them, which is exactly why toggling off and back on "fixes" it.

Because the Radix switch draws its track and thumb entirely from those `data-*` attributes, the control sat visually and semantically in the off position while dark mode was genuinely on. `aria-checked="false"` means screen readers announced "Dark Mode, off" too.

**The fix**

Seed the state with the same value the server renders, then resolve the real theme in an effect after hydration. The first client render now matches the server markup exactly, and the correction arrives as a genuine state transition that re-renders every theme-dependent control.

This also fixes the appearance selector in Settings, which highlighted "Light" as active on a dark load for the same underlying reason.

Two smaller things fall out of the same function:

- The stored value is now validated instead of being cast with `as Theme`. Previously any junk in `localStorage` (`theme=sepia`) was adopted as the theme and written straight back; it now falls back to the system preference.
- `"theme"` is lifted into a `STORAGE_KEY` constant so the provider and its tests can't drift apart.

No behaviour change for visitors already on light mode, and no new dependencies.

**Verification evidence**

Reproduced and confirmed against a real SSR dev server. `curl` shows the server unconditionally emits `data-state="unchecked"`; the browser column is the hydrated DOM:

| Scenario | `<html>` dark | Switch before | Switch after |
|---|---|---|---|
| Stored `dark` | yes | `unchecked` ❌ | `checked` ✅ |
| No stored value, OS dark, 375px mobile (the reported repro) | yes | `unchecked` ❌ | `checked` ✅ |
| Stored `light`, OS dark | no | `unchecked` ✅ | `unchecked` ✅ |
| Click to toggle | flips | ✅ | ✅ |

The switch hydration-mismatch error is gone from the console after the change.

**Tests**

Adds `app/src/lib/__tests__/themeProvider.test.tsx` (6 cases). Confirmed these genuinely fail on `main` and pass with the fix — two of them fail without it, including the SSR-agreement case and the unrecognised-stored-value case.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required

`pnpm --filter app test` passes (28 tests, 6 new). `pnpm --filter api test` was not run locally — it refuses to start without a local Supabase and this change touches no API code.
