### PR TITLE
fix(app): improved prerquisite validation logic and added invalid style

### DIFF
--- a/app/src/components/contribute/steps/GuideDetails.tsx
+++ b/app/src/components/contribute/steps/GuideDetails.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 import { useState } from "react";
+import { normalizeTodoTitle, todoPrereqSchema } from "@bluelearn/schemas";
 import type { Dispatch, SetStateAction } from "react";
 import type {
   ContributionType,
@@ -10,6 +11,7 @@ import { StepperActionHeader } from "@/components/contribute/StepperActionHeader
 import {
   Field,
   FieldDescription,
+  FieldError,
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
@@ -66,6 +68,10 @@ export const GuideDetails = ({
     title: "",
     summary: "",
   });
+  const [todoPrereqError, setTodoPrereqError] = useState<{
+    field: "title" | "summary";
+    message: string;
+  } | null>(null);
   const [newSubject, setNewSubject] = useState<{
     name: string;
     summary: string;
@@ -390,13 +396,18 @@ export const GuideDetails = ({
                   type="text"
                   maxLength={50}
                   placeholder="Enter title of missing prerequisite guide."
-                  className="h-10 rounded-md"
+                  className={`h-10 rounded-md ${todoPrereqError ? "outline-2 outline-offset-2 outline-destructive" : ""}`}
                   value={todoPrereq.title}
-                  onChange={(e) =>
+                  onChange={(e) => {
+                    setTodoPrereqError(null);
                     setTodoPrereq((prev) => ({
                       ...prev,
                       title: e.target.value,
-                    }))
+                    }));
+                  }}
+                  aria-invalid={!!todoPrereqError}
+                  aria-describedby={
+                    todoPrereqError ? "todo-prereq-error" : undefined
                   }
                 />
 
@@ -405,34 +416,69 @@ export const GuideDetails = ({
                   type="text"
                   maxLength={500}
                   placeholder="Enter summary of missing prerequisite guide."
-                  className="h-10 rounded-md"
+                  className={`h-10 rounded-md ${todoPrereqError ? "outline-2 outline-offset-2 outline-destructive" : ""}`}
                   value={todoPrereq.summary}
-                  onChange={(e) =>
+                  onChange={(e) => {
+                    setTodoPrereqError(null);
                     setTodoPrereq((prev) => ({
                       ...prev,
                       summary: e.target.value,
-                    }))
+                    }));
+                  }}
+                  aria-invalid={!!todoPrereqError}
+                  aria-describedby={
+                    todoPrereqError ? "todo-prereq-error" : undefined
                   }
                 />
                 <Button
+                  type="button"
                   variant="ghost"
                   size="icon"
                   className="btn-sec h-10 w-full rounded-md sm:w-24"
                   onClick={() => {
-                    if (todoPrereq.title !== "" && todoPrereq.summary !== "") {
-                      const todos = [...guideContData.todoPrereqs, todoPrereq];
-                      setGuideContData((prev) => ({
-                        ...prev,
-                        todoPrereqs: todos,
-                      }));
-
-                      setTodoPrereq({ title: "", summary: "" });
+                    const result = todoPrereqSchema.safeParse(todoPrereq);
+                    if (!result.success) {
+                      const issue = result.error.issues[0];
+                      const field =
+                        issue.path[0] === "summary" ? "summary" : "title";
+                      setTodoPrereqError({
+                        field,
+                        message: issue.message,
+                      });
+                      return;
                     }
+
+                    const normalizedTitle = normalizeTodoTitle(
+                      result.data.title
+                    );
+                    if (
+                      guideContData.todoPrereqs.some(
+                        (todo) =>
+                          normalizeTodoTitle(todo.title) === normalizedTitle
+                      )
+                    ) {
+                      setTodoPrereqError({
+                        field: "title",
+                        message:
+                          "A TODO prerequisite with this title already exists.",
+                      });
+                      return;
+                    }
+
+                    setGuideContData((prev) => ({
+                      ...prev,
+                      todoPrereqs: [...prev.todoPrereqs, result.data],
+                    }));
+                    setTodoPrereq({ title: "", summary: "" });
+                    setTodoPrereqError(null);
                   }}
                 >
                   Add Todo
                 </Button>
               </div>
+              <FieldError id="todo-prereq-error">
+                {todoPrereqError ? todoPrereqError.message : null}
+              </FieldError>
             </Field>
             {guideContData.todoPrereqs.length > 0 && (
               <div className="flex flex-col gap-2 px-1">

--- a/packages/schemas/src/guides/requests.ts
+++ b/packages/schemas/src/guides/requests.ts
@@ -5,7 +5,6 @@ import {
   guideSlugSchema,
   guideSummarySchema,
   guideTitleSchema,
-  guideTodoTitleSchema,
 } from "./fields";
 import { subjectNameSchema, subjectSummarySchema } from "../subjects";
 import {
@@ -27,8 +26,16 @@ export const newSubjectSchema = z.object({
 });
 
 export const todoPrereqSchema = z.object({
-  title: guideTodoTitleSchema,
-  summary: guideSummarySchema,
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(50, "Title must be 50 characters or less"),
+  summary: z
+    .string()
+    .trim()
+    .min(1, "Summary is required")
+    .max(500, "Summary must be 500 characters or less"),
 });
 
 export const createGuideSchema = z.object({


### PR DESCRIPTION


## Summary
I fixed the logic for the prereq when trying to submit an invalid prereq guide
and added styling for when it is invalid

before:
<img width="1245" height="233" alt="image" src="https://github.com/user-attachments/assets/a0fdabcb-6bc7-4fad-8c42-e9c1051fd3c0" />

after:
<img width="1363" height="153" alt="image" src="https://github.com/user-attachments/assets/250d964e-7691-4077-a05a-b781f1dd9773" />
<img width="1334" height="148" alt="image" src="https://github.com/user-attachments/assets/8640167e-797a-4c7a-967d-c186a78bad4d" />


## Type of change
bug
<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI /behaviourr changes)
- [ ] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
