### PR TITLE
fix(app): display prerequisites on edit screen

### DIFF
--- a/app/src/components/contribute/steps/GuideDetails.tsx
+++ b/app/src/components/contribute/steps/GuideDetails.tsx
@@ -38,6 +38,7 @@ type PropTypes = {
   onSaveDraft: () => void;
   submitting?: boolean;
   showBaseFields?: boolean;
+  showPrerequisiteFields?: boolean;
   hideBackBtn?: boolean;
   title?: string;
   changeSummary?: string;
@@ -56,6 +57,7 @@ export const GuideDetails = ({
   // Prerequisites and todos live on the guide base, so they're only
   // authorable while the base is still a draft.
   showBaseFields = true,
+  showPrerequisiteFields = showBaseFields,
   hideBackBtn,
   title = "Guide Details",
   changeSummary,
@@ -347,7 +349,7 @@ export const GuideDetails = ({
           </div>
         )}
 
-        {showBaseFields && (
+        {showPrerequisiteFields && (
           <>
             <Field className="space-y-2">
               <div className="space-y-1">
@@ -377,6 +379,7 @@ export const GuideDetails = ({
                     prereqs,
                   }))
                 }
+                disabled={!showBaseFields}
               />
             </Field>
 
@@ -409,6 +412,7 @@ export const GuideDetails = ({
                   aria-describedby={
                     todoPrereqError ? "todo-prereq-error" : undefined
                   }
+                  disabled={!showBaseFields}
                 />
 
                 <Input
@@ -429,6 +433,7 @@ export const GuideDetails = ({
                   aria-describedby={
                     todoPrereqError ? "todo-prereq-error" : undefined
                   }
+                  disabled={!showBaseFields}
                 />
                 <Button
                   type="button"
@@ -472,6 +477,7 @@ export const GuideDetails = ({
                     setTodoPrereq({ title: "", summary: "" });
                     setTodoPrereqError(null);
                   }}
+                  disabled={!showBaseFields}
                 >
                   Add Todo
                 </Button>
@@ -512,6 +518,7 @@ export const GuideDetails = ({
                           ),
                         }))
                       }
+                      disabled={!showBaseFields}
                     >
                       <X className="size-3" />
                     </button>

--- a/app/src/components/ui/combobox.tsx
+++ b/app/src/components/ui/combobox.tsx
@@ -150,6 +150,7 @@ export function Combobox({
               <button
                 type="button"
                 aria-label={`Remove ${item.label}`}
+                disabled={disabled}
                 className="text-muted-foreground hover:text-foreground"
                 onClick={() => toggle(item.value)}
               >

--- a/app/src/routes/guides/$slug/$variantSlug/edit.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/edit.tsx
@@ -331,6 +331,7 @@ function RouteComponent() {
                   onSaveDraft={saveDraft}
                   submitting={submitting}
                   showBaseFields={false}
+                  showPrerequisiteFields
                   hideBackBtn
                   title="Edit Details"
                   changeSummary={changeSummary}


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->
Made the prerequisite guides(both exising and to-do) visible on the Edit Guide screen without allowing them to be modified. Added a prop `showPrerequisiteFields`  to separate visibility from editability

## Type of change

<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required

Closes #363 #321