### PR TITLE
fix(app): keep formatted headings in table of contents

### DIFF
--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -62,15 +62,14 @@ export const GuideReader = ({
   const renderHeading =
     (level: number) =>
     ({ children }: any) => {
-      const text = Array.isArray(children)
-        ? children
-            .map((child) =>
-              typeof child === "string" || typeof child === "number"
-                ? String(child)
-                : (child?.props?.children ?? "")
-            )
-            .join("")
-        : String(children ?? "");
+      const getText = (value: any): string => {
+        if (typeof value === "string" || typeof value === "number") {
+          return String(value);
+        }
+        if (Array.isArray(value)) return value.map(getText).join("");
+        return getText(value?.props?.children);
+      };
+      const text = getText(children);
 
       return createElement(
         `h${level}`,

--- a/app/src/lib/guideUtils.ts
+++ b/app/src/lib/guideUtils.ts
@@ -89,6 +89,11 @@ const slugifyHeading = (text: string) =>
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-");
 
+const getMarkdownText = (node: any): string => {
+  if (typeof node.value === "string") return node.value;
+  return node.children?.map(getMarkdownText).join("") ?? "";
+};
+
 // extract headings from markdown content
 export const extractHeadings = (markdown: string) => {
   const tree = unified().use(remarkParse).parse(markdown);
@@ -98,7 +103,7 @@ export const extractHeadings = (markdown: string) => {
 
   function walk(node: any) {
     if (node.type === "heading") {
-      const text = node.children?.map((c: any) => c.value ?? "").join("") || "";
+      const text = getMarkdownText(node).trim();
       const base = slugifyHeading(text);
       const count = seen.get(base) ?? 0;
       const id = count === 0 ? base : `${base}-${count + 1}`;


### PR DESCRIPTION
## Summary

Fixed invisible table-of-contents headings by extracting formatted markdown text and generating matching anchor IDs.

<!-- Required: Describe what changed and why. -->

## Type of change
<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behaviour changes)
- [ ] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
