### PR TITLE
feat: add styling for markdown links

### DIFF
--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -247,6 +247,10 @@
   .markdown img {
     @apply my-4 h-auto max-w-full rounded-lg;
   }
+
+  .markdown a {
+    @apply text-primary underline;
+  }
 }
 
 /* == COMPONENT UTILITIES == */


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->
Add styling (text-primary and underline) for links in markdown guide reader.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [X] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
