### PR TITLE
fix: get text function returns blank string if no conditions match

### DIFF
--- a/app/src/components/GuideReader.tsx
+++ b/app/src/components/GuideReader.tsx
@@ -63,12 +63,25 @@ export const GuideReader = ({
     (level: number) =>
     ({ children }: any) => {
       const getText = (value: any): string => {
+        if (value == null) {
+          return "";
+        }
+
         if (typeof value === "string" || typeof value === "number") {
           return String(value);
         }
-        if (Array.isArray(value)) return value.map(getText).join("");
-        return getText(value?.props?.children);
+
+        if (Array.isArray(value)) {
+          return value.map(getText).join("");
+        }
+
+        if (value?.props?.children != null) {
+          return getText(value.props.children);
+        }
+
+        return "";
       };
+
       const text = getText(children);
 
       return createElement(


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->
Fix getText function recursive issue displaying "Maximum call stack size exceeded" error

## Type of change

<!-- Check the ONE that best describes this change. -->

- [X] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
