### PR TITLE
fix(app): require review notes to contain readable text

### DIFF
--- a/app/src/components/sidebar/ReviewSidebar.tsx
+++ b/app/src/components/sidebar/ReviewSidebar.tsx
@@ -14,6 +14,7 @@ import { Combobox } from "@/components/ui/combobox";
 
 import { cn } from "@/lib/utils";
 import { deadlineTickMs, formatTimeRemaining } from "@/lib/reviewDeadline";
+import { validateReviewDecision } from "@/lib/reviewValidation";
 import { castDecision } from "@/lib/api/reviews";
 import { getRevision, reviseRevision } from "@/lib/api/guideRevisions";
 import { GuidelinesModal } from "@/components/modals/GuidelinesModal";
@@ -102,19 +103,7 @@ export const ReviewSidebar = ({
     revisionData.case.status !== "approved" &&
     revisionData.case.status !== "rejected";
 
-  const validateReview = () => {
-    if (review.decision === "")
-      return "Choose approve or reject before submitting";
-    if (review.decision === "approve") return "";
-
-    const missing = [];
-    if (review.reasons.length === 0) missing.push("at least one reason");
-    if (review.notes.length === 0) missing.push("a note");
-
-    return missing.length === 0
-      ? ""
-      : `Rejections require ${missing.join(" and ")}`;
-  };
+  const validateReview = () => validateReviewDecision(review);
 
   const submitDecision = async () => {
     abortControllerRef.current?.abort();

--- a/app/src/lib/__tests__/reviewValidation.test.ts
+++ b/app/src/lib/__tests__/reviewValidation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasMeaningfulText,
+  validateReviewDecision,
+} from "@/lib/reviewValidation";
+
+const rejection = (notes: string) => ({
+  decision: "reject",
+  notes,
+  reasons: ["inaccurate"],
+});
+
+describe("hasMeaningfulText", () => {
+  it("accepts ordinary prose", () => {
+    expect(hasMeaningfulText("Needs a worked example.")).toBe(true);
+  });
+
+  it("accepts notes written in non-Latin scripts", () => {
+    expect(hasMeaningfulText("需要一个例子")).toBe(true);
+    expect(hasMeaningfulText("يحتاج إلى مثال")).toBe(true);
+    expect(hasMeaningfulText("Нужен пример")).toBe(true);
+  });
+
+  it("accepts a note that is only digits", () => {
+    expect(hasMeaningfulText("42")).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    expect(hasMeaningfulText("")).toBe(false);
+  });
+
+  it("rejects whitespace of any kind", () => {
+    expect(hasMeaningfulText("   ")).toBe(false);
+    expect(hasMeaningfulText("\t\n")).toBe(false);
+  });
+
+  it("rejects punctuation with no words", () => {
+    expect(hasMeaningfulText("...")).toBe(false);
+    expect(hasMeaningfulText("???")).toBe(false);
+    expect(hasMeaningfulText("-")).toBe(false);
+  });
+});
+
+describe("validateReviewDecision", () => {
+  it("asks for a decision before anything else", () => {
+    expect(
+      validateReviewDecision({ decision: "", notes: "", reasons: [] })
+    ).toBe("Choose approve or reject before submitting");
+  });
+
+  it("lets an approval through without notes or reasons", () => {
+    expect(
+      validateReviewDecision({ decision: "approve", notes: "", reasons: [] })
+    ).toBe("");
+  });
+
+  it("lets a complete rejection through", () => {
+    expect(validateReviewDecision(rejection("Missing prerequisites."))).toBe(
+      ""
+    );
+  });
+
+  // Regression test for #341: a note of only whitespace cleared the old
+  // `notes.length === 0` check, so it reached the API and failed there against
+  // `z.string().trim().min(1)` with a generic error instead of this guidance.
+  it("rejects a note that is only whitespace", () => {
+    expect(validateReviewDecision(rejection("   "))).toBe(
+      "Rejections require a note"
+    );
+  });
+
+  it("rejects a note that is only punctuation", () => {
+    expect(validateReviewDecision(rejection("..."))).toBe(
+      "Rejections require a note"
+    );
+  });
+
+  it("still requires at least one reason", () => {
+    expect(
+      validateReviewDecision({
+        decision: "reject",
+        notes: "Needs work.",
+        reasons: [],
+      })
+    ).toBe("Rejections require at least one reason");
+  });
+
+  it("reports both problems together", () => {
+    expect(
+      validateReviewDecision({ decision: "reject", notes: " ", reasons: [] })
+    ).toBe("Rejections require at least one reason and a note");
+  });
+});

--- a/app/src/lib/__tests__/reviewValidation.test.ts
+++ b/app/src/lib/__tests__/reviewValidation.test.ts
@@ -12,32 +12,19 @@ const rejection = (notes: string) => ({
 });
 
 describe("hasMeaningfulText", () => {
-  it("accepts ordinary prose", () => {
+  it("accepts letters and numbers in any script", () => {
     expect(hasMeaningfulText("Needs a worked example.")).toBe(true);
-  });
-
-  it("accepts notes written in non-Latin scripts", () => {
     expect(hasMeaningfulText("需要一个例子")).toBe(true);
     expect(hasMeaningfulText("يحتاج إلى مثال")).toBe(true);
     expect(hasMeaningfulText("Нужен пример")).toBe(true);
-  });
-
-  it("accepts a note that is only digits", () => {
     expect(hasMeaningfulText("42")).toBe(true);
   });
 
-  it("rejects an empty string", () => {
+  it("rejects input with no letters or numbers", () => {
     expect(hasMeaningfulText("")).toBe(false);
-  });
-
-  it("rejects whitespace of any kind", () => {
     expect(hasMeaningfulText("   ")).toBe(false);
     expect(hasMeaningfulText("\t\n")).toBe(false);
-  });
-
-  it("rejects punctuation with no words", () => {
     expect(hasMeaningfulText("...")).toBe(false);
-    expect(hasMeaningfulText("???")).toBe(false);
     expect(hasMeaningfulText("-")).toBe(false);
   });
 });
@@ -61,16 +48,10 @@ describe("validateReviewDecision", () => {
     );
   });
 
-  // Regression test for #341: a note of only whitespace cleared the old
-  // `notes.length === 0` check, so it reached the API and failed there against
-  // `z.string().trim().min(1)` with a generic error instead of this guidance.
-  it("rejects a note that is only whitespace", () => {
+  it("rejects a note with no readable text", () => {
     expect(validateReviewDecision(rejection("   "))).toBe(
       "Rejections require a note"
     );
-  });
-
-  it("rejects a note that is only punctuation", () => {
     expect(validateReviewDecision(rejection("..."))).toBe(
       "Rejections require a note"
     );

--- a/app/src/lib/reviewValidation.ts
+++ b/app/src/lib/reviewValidation.ts
@@ -1,0 +1,36 @@
+export type ReviewDecisionInput = {
+  decision: string;
+  notes: string;
+  reasons: Array<string>;
+};
+
+// A note has to carry something a guide author can actually read back. Any
+// letter or number in any script counts, so notes are not limited to Latin
+// characters; whitespace and bare punctuation are not a note.
+const MEANINGFUL_TEXT = /[\p{L}\p{N}]/u;
+
+export function hasMeaningfulText(value: string): boolean {
+  return MEANINGFUL_TEXT.test(value);
+}
+
+/**
+ * Describes what is stopping a decision from being submitted, or returns an
+ * empty string when it is ready to go.
+ *
+ * `createDecisionSchema` already requires `notes` to survive a trim on the
+ * server, so a blank-but-not-empty note used to clear this check and fail at
+ * the API instead, surfacing a generic error rather than the guidance below.
+ */
+export function validateReviewDecision(review: ReviewDecisionInput): string {
+  if (review.decision === "")
+    return "Choose approve or reject before submitting";
+  if (review.decision === "approve") return "";
+
+  const missing = [];
+  if (review.reasons.length === 0) missing.push("at least one reason");
+  if (!hasMeaningfulText(review.notes)) missing.push("a note");
+
+  return missing.length === 0
+    ? ""
+    : `Rejections require ${missing.join(" and ")}`;
+}

--- a/app/src/lib/reviewValidation.ts
+++ b/app/src/lib/reviewValidation.ts
@@ -4,9 +4,8 @@ export type ReviewDecisionInput = {
   reasons: Array<string>;
 };
 
-// A note has to carry something a guide author can actually read back. Any
-// letter or number in any script counts, so notes are not limited to Latin
-// characters; whitespace and bare punctuation are not a note.
+// Any letter or number in any script counts, so notes are not limited to Latin
+// characters. Whitespace and bare punctuation are not a note.
 const MEANINGFUL_TEXT = /[\p{L}\p{N}]/u;
 
 export function hasMeaningfulText(value: string): boolean {
@@ -16,10 +15,6 @@ export function hasMeaningfulText(value: string): boolean {
 /**
  * Describes what is stopping a decision from being submitted, or returns an
  * empty string when it is ready to go.
- *
- * `createDecisionSchema` already requires `notes` to survive a trim on the
- * server, so a blank-but-not-empty note used to clear this check and fail at
- * the API instead, surfacing a generic error rather than the guidance below.
  */
 export function validateReviewDecision(review: ReviewDecisionInput): string {
   if (review.decision === "")


### PR DESCRIPTION
## Summary

Closes #341.

The client checked `notes.length === 0`, while `createDecisionSchema` requires `z.string().trim().min(1)`. A whitespace-only note therefore passed the client gate and failed at the API, showing a generic error instead of the sidebar's own message.

Now checks that the note contains a letter or number, so whitespace and bare punctuation are caught before submitting. The check moved to `lib/reviewValidation.ts` so it can be unit tested; the call site is otherwise unchanged.

**One question:** this is deliberately stricter than the schema — `"..."` passes zod but fails here — matching "at least one word" from the issue. Happy to relax it to a plain trim, or to tighten `createDecisionSchema` so both match. Say which and I'll push a follow-up.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes) — see below
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required

41 tests pass (13 new). I couldn't exercise the sidebar in a browser — reaching a case needs a local Supabase and I don't have Docker on this machine — so the logic is covered by unit tests instead.
