### PR TITLE
feat(profile): add filter by subject in profile activity

### DIFF
--- a/api/src/services/identity.service.ts
+++ b/api/src/services/identity.service.ts
@@ -319,6 +319,7 @@ export type ProfileActivityRow = {
   base_slug: string | null;
   review_case_id: string | null;
   revision_id: string | null;
+  subjects: Array<{ slug: string; name: string }>;
 };
 
 // Earliest revision id per parent, so a row can be tagged as the "creation"
@@ -463,6 +464,7 @@ export async function getProfileActivity(
         base_slug: guide ? (slugByBase.get(guide.guide_base_id) ?? null) : null,
         review_case_id: caseId,
         revision_id: rev.id,
+        subjects: [],
       });
     }
   }
@@ -509,6 +511,7 @@ export async function getProfileActivity(
         base_slug: null,
         review_case_id: null,
         revision_id: rev.id,
+        subjects: [],
       });
     }
   }
@@ -615,7 +618,43 @@ export async function getProfileActivity(
             ? caseId
             : null,
           revision_id: rev ?? null,
+          subjects: [],
         });
+      }
+    }
+  }
+
+  // Batch-fetch subject tags for all guide revision rows in one query.
+  const guideRevisionIds = rows
+    .filter((r) => r.content_kind === "guide" && r.revision_id !== null)
+    .map((r) => r.revision_id as string);
+
+  if (guideRevisionIds.length > 0) {
+    const { data: tagData, error: tagError } = await supabase
+      .from("guide_revision_subjects")
+      .select("guide_revision_id, subjects(slug, name)")
+      .in("guide_revision_id", guideRevisionIds);
+
+    if (tagError) fail(tagError);
+
+    // Build a map from revision_id -> subject list, then hydrate the rows.
+    const subjectsByRev = new Map<
+      string,
+      Array<{ slug: string; name: string }>
+    >();
+    for (const tag of tagData ?? []) {
+      const subj = tag.subjects;
+      if (!subj || typeof subj !== "object" || Array.isArray(subj)) continue;
+      const { slug, name } = subj as { slug: string | null; name: string };
+      if (slug === null) continue;
+      const list = subjectsByRev.get(tag.guide_revision_id) ?? [];
+      list.push({ slug, name });
+      subjectsByRev.set(tag.guide_revision_id, list);
+    }
+
+    for (const row of rows) {
+      if (row.content_kind === "guide" && row.revision_id !== null) {
+        row.subjects = subjectsByRev.get(row.revision_id) ?? [];
       }
     }
   }

--- a/api/tests/identity.test.ts
+++ b/api/tests/identity.test.ts
@@ -14,6 +14,7 @@ import {
   createGuideRevision,
   createPublishedGuide,
 } from "./factories/guides";
+import { createSubject, tagGuideRevision } from "./factories/subjects";
 import { expectToMatchSpec } from "./openapi";
 
 describe("GET /me", () => {
@@ -196,5 +197,47 @@ describe("GET /profiles/{username}", () => {
 
     expect(res.status).toBe(404);
     await expectToMatchSpec(res, "GET", "/profiles/{username}");
+  });
+
+  it("includes subject tags on guide revision activity rows", async () => {
+    const { token, userId } = await makeUser();
+    const username = await getUsername(userId);
+    const subject = await createSubject();
+    const { revision } = await createPublishedGuide({ authorId: userId });
+    await tagGuideRevision(revision.id, subject.id);
+
+    const res = await app.request(`/profiles/${username}`, auth(token), env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      activity: Array<{
+        revision_id: string | null;
+        subjects: Array<{ slug: string; name: string }>;
+      }>;
+    };
+    const row = body.activity.find((r) => r.revision_id === revision.id);
+    expect(row).toBeDefined();
+    expect(row?.subjects).toEqual(
+      expect.arrayContaining([{ slug: subject.slug, name: subject.name }])
+    );
+  });
+
+  it("returns an empty subjects array for untagged guide revisions", async () => {
+    const { token, userId } = await makeUser();
+    const username = await getUsername(userId);
+    const { revision } = await createPublishedGuide({ authorId: userId });
+
+    const res = await app.request(`/profiles/${username}`, auth(token), env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      activity: Array<{
+        revision_id: string | null;
+        subjects: Array<{ slug: string; name: string }>;
+      }>;
+    };
+    const row = body.activity.find((r) => r.revision_id === revision.id);
+    expect(row).toBeDefined();
+    expect(row?.subjects).toEqual([]);
   });
 });

--- a/app/src/components/ActivityColumnFilters.tsx
+++ b/app/src/components/ActivityColumnFilters.tsx
@@ -191,9 +191,9 @@ export function ChoiceColumnFilter({
   setFilters,
 }: {
   label: string;
-  field: "type" | "status";
+  field: "type" | "status" | "subject";
   options: ReadonlyArray<{
-    value: ActivityTypeFilter | ActivityStatusFilter;
+    value: ActivityTypeFilter | ActivityStatusFilter | string;
     label: string;
   }>;
   search: ActivityFilters;

--- a/app/src/components/profile/ActivityTable.tsx
+++ b/app/src/components/profile/ActivityTable.tsx
@@ -7,6 +7,7 @@ import {
   activityStatusLabel,
   activityTypeLabel,
   filterActivity,
+  getActivitySubjectOptions,
 } from "@/lib/profile";
 import { formatDate } from "@/lib/guideUtils";
 import { cn } from "@/lib/utils";
@@ -95,6 +96,7 @@ export function ActivityTable({
   const hasFilters = Boolean(
     search.type?.length ||
     search.status?.length ||
+    search.subject?.length ||
     search.title ||
     search.summary ||
     search.from ||
@@ -119,6 +121,10 @@ export function ActivityTable({
   const emptyMessage = hasFilters
     ? "No activity matches these filters."
     : "No activity available yet.";
+
+  // Derive subject options from the full activity (before filtering) so all
+  // available subject choices are always visible, even when other filters are active.
+  const subjectOptions = getActivitySubjectOptions(activity);
 
   return (
     <>
@@ -151,6 +157,15 @@ export function ActivityTable({
             search={search}
             setFilters={setFilters}
           />
+          {subjectOptions.length > 0 && (
+            <ChoiceColumnFilter
+              label="Subject"
+              field="subject"
+              options={subjectOptions}
+              search={search}
+              setFilters={setFilters}
+            />
+          )}
         </div>
 
         {pageRows.length === 0 ? (
@@ -186,6 +201,20 @@ export function ActivityTable({
                     <p className="text-sm text-muted-foreground">
                       {row.change_summary}
                     </p>
+                  )}
+
+                  {row.subjects.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {row.subjects.map((s) => (
+                        <Badge
+                          key={s.slug}
+                          variant="outline"
+                          className="mono-micro rounded-full border border-badge-border bg-badge tracking-[0.08em] text-badge-foreground"
+                        >
+                          {s.name}
+                        </Badge>
+                      ))}
+                    </div>
                   )}
 
                   <div className="flex items-center justify-between gap-3">
@@ -257,6 +286,19 @@ export function ActivityTable({
                 />
               </TableHead>
               <TableHead className="px-4 py-3 font-mono text-[14px] font-bold tracking-[0.08em] uppercase">
+                {subjectOptions.length > 0 ? (
+                  <ChoiceColumnFilter
+                    label="Subject"
+                    field="subject"
+                    options={subjectOptions}
+                    search={search}
+                    setFilters={setFilters}
+                  />
+                ) : (
+                  "Subject"
+                )}
+              </TableHead>
+              <TableHead className="px-4 py-3 font-mono text-[14px] font-bold tracking-[0.08em] uppercase">
                 Review Case
               </TableHead>
             </TableRow>
@@ -265,7 +307,7 @@ export function ActivityTable({
             {pageRows.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={6}
+                  colSpan={7}
                   className="px-4 py-6 text-center text-sm text-muted-foreground"
                 >
                   {emptyMessage}
@@ -301,6 +343,24 @@ export function ActivityTable({
                       >
                         {activityStatusLabel(row.status)}
                       </Badge>
+                    </TableCell>
+
+                    <TableCell className="px-4 py-3">
+                      {row.subjects.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {row.subjects.map((s) => (
+                            <Badge
+                              key={s.slug}
+                              variant="outline"
+                              className="mono-micro rounded-full border border-badge-border bg-badge tracking-[0.08em] text-badge-foreground"
+                            >
+                              {s.name}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
                     </TableCell>
 
                     <TableCell className="px-4 py-3">

--- a/app/src/lib/__tests__/profile.test.ts
+++ b/app/src/lib/__tests__/profile.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { getAvatarUrl, getInitials } from "../profile";
+import {
+  filterActivity,
+  getActivitySubjectOptions,
+  getAvatarUrl,
+  getInitials,
+} from "../profile";
+import type { ProfileActivityItem } from "@bluelearn/schemas";
+
+function makeRow(
+  overrides: Partial<ProfileActivityItem> = {}
+): ProfileActivityItem {
+  return {
+    content_kind: "guide",
+    is_variant: false,
+    is_creation: true,
+    title: "Test",
+    change_summary: null,
+    created_at: new Date().toISOString(),
+    status: "published",
+    target_slug: "test-guide",
+    base_slug: "test-base",
+    review_case_id: null,
+    revision_id: crypto.randomUUID(),
+    subjects: [],
+    ...overrides,
+  };
+}
 
 describe("getInitials", () => {
   it("extracts up to two initials from single-word and multi-word names", () => {
@@ -25,5 +51,70 @@ describe("getAvatarUrl", () => {
     expect(getAvatarUrl("")).toBe("");
     expect(getAvatarUrl(null)).toBe("");
     expect(getAvatarUrl(undefined)).toBe("");
+  });
+});
+
+describe("filterActivity — subject", () => {
+  const js = { slug: "javascript", name: "JavaScript" };
+  const react = { slug: "react", name: "React" };
+
+  const rowJs = makeRow({ subjects: [js] });
+  const rowReact = makeRow({ subjects: [react] });
+  const rowBoth = makeRow({ subjects: [js, react] });
+  const rowNone = makeRow({ subjects: [] });
+
+  it("returns all rows when no subject filter is set", () => {
+    const result = filterActivity([rowJs, rowReact, rowNone], {});
+    expect(result).toHaveLength(3);
+  });
+
+  it("keeps only rows that match at least one selected subject slug", () => {
+    const result = filterActivity([rowJs, rowReact, rowBoth, rowNone], {
+      subject: ["javascript"],
+    });
+    expect(result).toContain(rowJs);
+    expect(result).toContain(rowBoth);
+    expect(result).not.toContain(rowReact);
+    expect(result).not.toContain(rowNone);
+  });
+
+  it("matches rows that have any of the selected subjects (OR semantics)", () => {
+    const result = filterActivity([rowJs, rowReact, rowBoth, rowNone], {
+      subject: ["javascript", "react"],
+    });
+    expect(result).toContain(rowJs);
+    expect(result).toContain(rowReact);
+    expect(result).toContain(rowBoth);
+    expect(result).not.toContain(rowNone);
+  });
+
+  it("returns empty array when no rows match the selected subject", () => {
+    const result = filterActivity([rowNone], { subject: ["javascript"] });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("getActivitySubjectOptions", () => {
+  it("derives unique sorted subject options from activity rows", () => {
+    const rows = [
+      makeRow({ subjects: [{ slug: "react", name: "React" }] }),
+      makeRow({
+        subjects: [
+          { slug: "javascript", name: "JavaScript" },
+          { slug: "react", name: "React" },
+        ],
+      }),
+      makeRow({ subjects: [] }),
+    ];
+    const options = getActivitySubjectOptions(rows);
+    expect(options).toEqual([
+      { value: "javascript", label: "JavaScript" },
+      { value: "react", label: "React" },
+    ]);
+  });
+
+  it("returns an empty array when no rows have subjects", () => {
+    const rows = [makeRow({ subjects: [] }), makeRow({ subjects: [] })];
+    expect(getActivitySubjectOptions(rows)).toEqual([]);
   });
 });

--- a/app/src/lib/profile.ts
+++ b/app/src/lib/profile.ts
@@ -74,6 +74,22 @@ export const ACTIVITY_STATUS_FILTERS: Array<{
   { value: "rejected", label: "Rejected" },
 ];
 
+// Derive unique subjects present in a set of activity rows, sorted by name.
+// Used to populate the Subject filter options with only relevant choices.
+export function getActivitySubjectOptions(
+  rows: Array<ActivityRow>
+): Array<{ value: string; label: string }> {
+  const seen = new Map<string, string>();
+  for (const row of rows) {
+    for (const subject of row.subjects) {
+      if (!seen.has(subject.slug)) seen.set(subject.slug, subject.name);
+    }
+  }
+  return [...seen.entries()]
+    .sort(([, a], [, b]) => a.localeCompare(b))
+    .map(([value, label]) => ({ value, label }));
+}
+
 export const ACTIVITY_SORTS = activitySortSchema.options;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -100,7 +116,7 @@ const SORTERS: Record<
 
 export function filterActivity(
   rows: Array<ActivityRow>,
-  { type, status, title, summary, from, to, sort }: ActivityFilters
+  { type, status, subject, title, summary, from, to, sort }: ActivityFilters
 ): Array<ActivityRow> {
   const titleNeedle = title?.trim().toLowerCase();
   const summaryNeedle = summary?.trim().toLowerCase();
@@ -109,6 +125,7 @@ export function filterActivity(
   const statuses = status?.length
     ? new Set(status.flatMap((s) => STATUS_BUCKETS[s]))
     : null;
+  const subjectSlugs = subject?.length ? new Set(subject) : null;
   const fromMs = from ? localDayMs(from) : null;
   // 'to' is a whole day, so include everything before the next midnight
   const toMs = to ? localDayMs(to) + DAY_MS : null;
@@ -116,6 +133,8 @@ export function filterActivity(
   const matched = rows.filter((row) => {
     if (types && !types.has(activityTypeKey(row))) return false;
     if (statuses && !statuses.has(row.status)) return false;
+    if (subjectSlugs && !row.subjects.some((s) => subjectSlugs.has(s.slug)))
+      return false;
     if (titleNeedle && !row.title.toLowerCase().includes(titleNeedle))
       return false;
     if (

--- a/packages/schemas/src/identity/requests.ts
+++ b/packages/schemas/src/identity/requests.ts
@@ -36,6 +36,7 @@ const filterList = <T extends string>(schema: z.ZodType<T>) =>
 export const profileActivitySearchSchema = z.object({
   type: filterList(activityTypeFilterSchema),
   status: filterList(activityStatusFilterSchema),
+  subject: filterList(z.string().min(1)),
   title: z.string().min(1).optional().catch(undefined),
   summary: z.string().min(1).optional().catch(undefined),
   from: z.iso.date().optional().catch(undefined),

--- a/packages/schemas/src/identity/responses.ts
+++ b/packages/schemas/src/identity/responses.ts
@@ -68,6 +68,7 @@ export const profileActivityItemSchema = z.object({
   base_slug: z.string().nullable(),
   review_case_id: z.uuid().nullable(),
   revision_id: z.uuid().nullable(),
+  subjects: z.array(z.object({ slug: z.string(), name: z.string() })),
 });
 
 export const meResponseSchema = z.strictObject({


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->

Allows users to filter profile guide activity by subject, following Bluelearn's established query-parameter filtering architecture, schema conventions, and UI patterns.

Closes #383 

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
