### PR TITLE
fix(api): fix variant's case type on review index page and review sidebar

### DIFF
--- a/api/src/routes/reviews.ts
+++ b/api/src/routes/reviews.ts
@@ -50,6 +50,7 @@ export const reviewsRouter = new Hono<HonoEnv>()
       const { page, limit } = c.req.valid("query");
       const { data, total } = await getReviewQueue(
         c.get("supabase"),
+        getServiceSupabase(c),
         c.get("user").id,
         { page, limit }
       );

--- a/api/src/services/review.service.ts
+++ b/api/src/services/review.service.ts
@@ -38,7 +38,15 @@ type QueueRow = {
 type GuideLinkRow = {
   case_id: string;
   guide_revision_id: string;
-  guide_revisions: { title: string | null; summary: string | null };
+  guide_revisions: {
+    title: string | null;
+    summary: string | null;
+    guide_id: string;
+    guides: {
+      guide_base_id: string;
+      guide_bases: { canonical_guide_id: string | null } | null;
+    } | null;
+  };
 };
 
 type CaseListRow = {
@@ -113,6 +121,7 @@ type CaseDetailRow = {
 
 type TagsAndEdges = {
   knowledge_type: Database["public"]["Enums"]["knowledge_type"] | null;
+  is_variant: boolean;
   base: { slug: string; title: string | null } | null;
   tags: Array<{ id: string; name: string; status: string }>;
   prerequisites: Array<{ slug: string; title: string | null }>;
@@ -127,6 +136,7 @@ type TagsAndEdges = {
 
 export async function getReviewQueue(
   supabase: DB,
+  service: DB,
   userId: string,
   { page, limit }: Pagination = { page: 1, limit: 20 }
 ) {
@@ -162,10 +172,17 @@ export async function getReviewQueue(
 
   let guideLinks: GuideLinkRow[] = [];
   if (caseIds.length > 0) {
-    const { data: links, error: linkError } = await supabase
+    const { data: links, error: linkError } = await service
       .from("guide_review_cases")
       .select(
-        "case_id, guide_revision_id, guide_revisions!inner(title, summary)"
+        `case_id, guide_revision_id,
+        guide_revisions!inner(
+          title, summary, guide_id,
+          guides!guide_revisions_guide_id_fkey!inner(
+            guide_base_id,
+            guide_bases!guides_guide_base_id_fkey!inner(canonical_guide_id)
+          )
+        )`
       )
       .in("case_id", caseIds);
 
@@ -180,12 +197,16 @@ export async function getReviewQueue(
     .map((m) => {
       const rc = m.review_panels.review_cases;
       const link = guideLinks.find((l) => l.case_id === rc.id);
+      const canonicalId =
+        link?.guide_revisions?.guides?.guide_bases?.canonical_guide_id ?? null;
+      const guideId = link?.guide_revisions?.guide_id ?? null;
 
       return {
         id: rc.id,
         case_type: rc.case_type,
         status: rc.status,
         title: link?.guide_revisions?.title ?? null,
+        is_variant: canonicalId != null && canonicalId !== guideId,
         created_at: rc.created_at,
         decision: m.review_decisions?.decision ?? null,
         expires_at: m.expires_at,
@@ -247,6 +268,7 @@ async function loadTagsAndEdges(
        guide_bases!guides_guide_base_id_fkey(
          knowledge_type,
          slug,
+         canonical_guide_id,
          canonical:guides!guide_bases_canonical_guide_id_fkey(
            current:guide_revisions!guides_current_revision_id_fkey(title)
          )
@@ -317,9 +339,11 @@ async function loadTagsAndEdges(
   }
 
   const baseSlug = guide?.guide_bases?.slug ?? null;
+  const canonicalId = guide?.guide_bases?.canonical_guide_id ?? null;
 
   return {
     knowledge_type: guide?.guide_bases?.knowledge_type ?? null,
+    is_variant: canonicalId != null && canonicalId !== guideId,
     base: baseSlug
       ? {
           slug: baseSlug,
@@ -503,6 +527,7 @@ export async function getReviewCase(
             ? (usernames.get(revision.author_id) ?? null)
             : null,
           knowledge_type: tagsAndEdges?.knowledge_type ?? null,
+          is_variant: tagsAndEdges?.is_variant ?? false,
           base: tagsAndEdges?.base ?? null,
           title: revision.title,
           summary: revision.summary,

--- a/app/src/components/sidebar/ReviewSidebar.tsx
+++ b/app/src/components/sidebar/ReviewSidebar.tsx
@@ -68,6 +68,8 @@ export const ReviewSidebar = ({
     revisionData.case.case_type === "official_publish" ||
     revisionData.case.case_type === "official_edit";
 
+  const isVariant = revision?.is_variant ?? false;
+
   const priorDecision = revisionData.viewer_decision;
   const hasVoted = priorDecision !== null;
 
@@ -217,8 +219,12 @@ export const ReviewSidebar = ({
                     />
                     <span className="translate-y-[0.25px]">
                       {isEdit
-                        ? "Official Guide Revision"
-                        : "Official Guide Creation"}
+                        ? isVariant
+                          ? "Official Variant Revision"
+                          : "Official Guide Revision"
+                        : isVariant
+                          ? "Official Variant Creation"
+                          : "Official Guide Creation"}
                     </span>
                   </Badge>
                 ) : (
@@ -226,7 +232,13 @@ export const ReviewSidebar = ({
                     variant="outline"
                     className="border-badge-border bg-badge font-mono tracking-[0.06em] text-badge-foreground uppercase"
                   >
-                    {isEdit ? "Guide Revision" : "Guide Creation"}
+                    {isEdit
+                      ? isVariant
+                        ? "Variant Revision"
+                        : "Guide Revision"
+                      : isVariant
+                        ? "Variant Creation"
+                        : "Guide Creation"}
                   </Badge>
                 )
               }

--- a/app/src/lib/api/reviews.ts
+++ b/app/src/lib/api/reviews.ts
@@ -12,6 +12,7 @@ export type QueueCase = {
   case_type: string;
   status: string;
   title: string | null;
+  is_variant: boolean;
   created_at: string;
   decision: "approved" | "rejected" | null;
   expires_at: string | null;

--- a/app/src/routes/review.index.tsx
+++ b/app/src/routes/review.index.tsx
@@ -119,6 +119,7 @@ function CaseGrid({ cases }: { cases: Array<QueueCase> }) {
           c.case_type === "official_publish" || c.case_type === "official_edit";
         const isEdit =
           c.case_type === "guide_edit" || c.case_type === "official_edit";
+        const isVariant = c.is_variant;
 
         return (
           <Link
@@ -131,7 +132,13 @@ function CaseGrid({ cases }: { cases: Array<QueueCase> }) {
               <div className="flex items-center justify-between">
                 <p className="font-mono text-xs tracking-wide text-muted-foreground uppercase">
                   {isOfficial ? "Official " : ""}
-                  {isEdit ? "Guide Revision" : "Guide Creation"}
+                  {isEdit
+                    ? isVariant
+                      ? "Variant Revision"
+                      : "Guide Revision"
+                    : isVariant
+                      ? "Variant Creation"
+                      : "Guide Creation"}
                 </p>
                 <Badge
                   variant="outline"

--- a/packages/schemas/src/review/responses.ts
+++ b/packages/schemas/src/review/responses.ts
@@ -12,6 +12,7 @@ export const reviewCaseListItemSchema = z.object({
   case_type: reviewCaseTypeSchema,
   status: reviewCaseStatusSchema,
   title: z.string().nullable(),
+  is_variant: z.boolean(),
   created_at: z.string(),
 });
 
@@ -77,6 +78,7 @@ export const reviewCaseDetailResponseSchema = z.strictObject({
       title: z.string().nullable(),
       summary: z.string().nullable(),
       body: z.string().nullable(),
+      is_variant: z.boolean(),
       status: z.string(),
       created_at: z.string(),
     })


### PR DESCRIPTION

## Summary

<!-- Required: Describe what changed and why. -->
Issue: Review pages showed "Guide Creation"/"Guide Revision" for every submission, even when the submission was a variant of an existing guide. Verifiers had no way to tell from the review UI whether they were reviewing a guide or a variant.

cause: The system tracks whether a guide is official, and whether it's an edit , but that field was not designed to identify whether its a variant and the `is_variant` info that exists in editor/draft flow cant be fetched through these review pages.

Changes:
`is_variant` now computed and returned on both review endpoints: `getReviewCase `and `getReviewQueue ` 
Frontend logic updated to check on `is_variant ` along with the existing isEdit/isOfficial checks. 

Note: Updated "Official variant creation" logic in the frontend but `is_official` couldnt identify it as official because the check happens with the base guide of a variant. Since we are not planning to make variants from official account, its not necessary to make those schema level updates 

## Type of change

<!-- Check the ONE that best describes this change. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required

Closes #367 