### PR TITLE
fix: toggling afk on user without status marks them as 'active'

### DIFF
--- a/api/src/routes/dashboard.ts
+++ b/api/src/routes/dashboard.ts
@@ -37,7 +37,7 @@ export const dashboardRouter = new Hono<HonoEnv>()
       summary: "View user status",
       responses: {
         200: jsonContent(userStatusResponseSchema, "User's status"),
-        ...errorResponses(400, 404),
+        ...errorResponses(400, 401, 404),
       },
     }),
     validate("param", idParamSchema),
@@ -56,7 +56,7 @@ export const dashboardRouter = new Hono<HonoEnv>()
       summary: "Change user status",
       responses: {
         200: jsonContent(updateStatusResponseSchema, "User's status"),
-        ...errorResponses(400, 401, 404),
+        ...errorResponses(400, 401),
       },
     }),
     requireUser,

--- a/api/src/services/dashboard.service.ts
+++ b/api/src/services/dashboard.service.ts
@@ -82,16 +82,12 @@ export async function markUserStatus(
 ) {
   const { data, error } = await supabase
     .from("user_statuses")
-    .update({ status: status })
-    .eq("user_id", userId)
+    .upsert({ user_id: userId, status: status })
     .select();
 
   if (error) {
     console.error(error);
     throw new ServiceError("Failed to update user status.", 500);
-  }
-  if (!data || data.length === 0) {
-    throw new ServiceError("Could not update status: User not found", 404);
   }
 
   return data;

--- a/supabase/migrations/20260905133442_statuses_insert_policy_update.sql
+++ b/supabase/migrations/20260905133442_statuses_insert_policy_update.sql
@@ -1,0 +1,6 @@
+create policy "Admins can insert statuses"
+on "public"."user_statuses"
+as permissive
+for insert
+to authenticated
+with check (public.has_role('admin'::public.app_role));


### PR DESCRIPTION
## Summary

When you select a user with no status in the admin dashboard and press "Toggle AFK", it will set their status to "Active." 
( Closes #399 )

## Type of change

<!-- Check the ONE that best describes this change. -->

- [X] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required [N/A]