### PR TITLE
feat(app): add pagination to todo page

### DIFF
--- a/app/src/lib/__tests__/groupTodos.test.ts
+++ b/app/src/lib/__tests__/groupTodos.test.ts
@@ -110,9 +110,21 @@ describe("groupTodosByTitle", () => {
   });
 
   it("preserves insertion order of the first occurrence of each normalized title", () => {
-    const todoA = makeTodoItem({ title: "Zebra Crossing" });
-    const todoB = makeTodoItem({ title: "Alpha Centauri" });
-    const todoA2 = makeTodoItem({ title: "zebra crossing" });
+    const todoA = makeTodoItem({
+      id: "zebra-1",
+      title: "Zebra Crossing",
+      created_at: "2026-01-01T10:00:00Z",
+    });
+    const todoB = makeTodoItem({
+      id: "alpha-1",
+      title: "Alpha Centauri",
+      created_at: "2026-01-01T11:00:00Z",
+    });
+    const todoA2 = makeTodoItem({
+      id: "zebra-2",
+      title: "zebra crossing",
+      created_at: "2026-01-02T10:00:00Z",
+    });
 
     const groups = groupTodosByTitle([todoA, todoB, todoA2]);
 

--- a/app/src/lib/__tests__/groupTodos.test.ts
+++ b/app/src/lib/__tests__/groupTodos.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { groupTodosByTitle } from "../groupTodos";
+import { usePagination } from "../usePagination";
+import type { TodoListItem } from "@bluelearn/schemas";
+
+function makeTodoItem(overrides: Partial<TodoListItem> = {}): TodoListItem {
+  return {
+    id: crypto.randomUUID(),
+    guide_base_id: crypto.randomUUID(),
+    guide_slug: "intro-to-math",
+    guide_title: "Intro to Math",
+    title: "Understanding Derivatives",
+    summary: "Need a comprehensive introduction to derivatives.",
+    status: "open",
+    claim_count: 0,
+    created_at: new Date("2026-01-01T10:00:00Z").toISOString(),
+    ...overrides,
+  };
+}
+
+describe("groupTodosByTitle", () => {
+  it("returns an empty array when given an empty list", () => {
+    expect(groupTodosByTitle([])).toEqual([]);
+  });
+
+  it("creates a single group for a single todo item", () => {
+    const todo = makeTodoItem({
+      title: "Linear Algebra",
+      summary: "Vector spaces and matrices",
+      claim_count: 2,
+    });
+
+    const groups = groupTodosByTitle([todo]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toEqual({
+      key: expect.any(String),
+      title: "Linear Algebra",
+      summary: "Vector spaces and matrices",
+      todoIds: [todo.id],
+      requestedBy: [{ slug: "intro-to-math", title: "Intro to Math" }],
+      claimCount: 2,
+    });
+  });
+
+  it("combines todos with equivalent normalized titles into one group", () => {
+    const todo1 = makeTodoItem({
+      id: "id-1",
+      title: "Linear Algebra Basics",
+      created_at: "2026-01-01T10:00:00Z",
+      guide_slug: "guide-a",
+      guide_title: "Guide A",
+      claim_count: 1,
+    });
+    const todo2 = makeTodoItem({
+      id: "id-2",
+      title: "linear-algebra-basics",
+      created_at: "2026-01-02T10:00:00Z",
+      guide_slug: "guide-b",
+      guide_title: "Guide B",
+      claim_count: 3,
+    });
+    const todo3 = makeTodoItem({
+      id: "id-3",
+      title: "  Linear   Algebra   Basics!  ",
+      created_at: "2026-01-03T10:00:00Z",
+      guide_slug: "guide-c",
+      guide_title: "Guide C",
+      claim_count: 0,
+    });
+
+    const groups = groupTodosByTitle([todo1, todo2, todo3]);
+
+    expect(groups).toHaveLength(1);
+    const [group] = groups;
+    expect(group.todoIds).toEqual(["id-1", "id-2", "id-3"]);
+    expect(group.claimCount).toBe(3); // maximum claim count
+    expect(group.requestedBy).toEqual([
+      { slug: "guide-a", title: "Guide A" },
+      { slug: "guide-b", title: "Guide B" },
+      { slug: "guide-c", title: "Guide C" },
+    ]);
+    // Keeps earliest created todo's title and summary
+    expect(group.title).toBe("Linear Algebra Basics");
+  });
+
+  it("ignores items whose title normalizes to an empty string", () => {
+    const invalidTodo = makeTodoItem({ title: "---!@#$$%---" });
+    const validTodo = makeTodoItem({ title: "Valid Title" });
+
+    const groups = groupTodosByTitle([invalidTodo, validTodo]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe("Valid Title");
+  });
+
+  it("filters out items without guide_slug from requestedBy", () => {
+    const todoWithoutSlug = makeTodoItem({
+      guide_slug: null,
+      guide_title: null,
+    });
+
+    const groups = groupTodosByTitle([todoWithoutSlug]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].requestedBy).toEqual([]);
+  });
+
+  it("preserves insertion order of the first occurrence of each normalized title", () => {
+    const todoA = makeTodoItem({ title: "Zebra Crossing" });
+    const todoB = makeTodoItem({ title: "Alpha Centauri" });
+    const todoA2 = makeTodoItem({ title: "zebra crossing" });
+
+    const groups = groupTodosByTitle([todoA, todoB, todoA2]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].title).toBe("Zebra Crossing");
+    expect(groups[1].title).toBe("Alpha Centauri");
+  });
+});
+
+describe("todo grouping & pagination invariants", () => {
+  const PAGE_SIZE = 10;
+
+  it("does not split raw duplicate rows across pages when total rows exceed PAGE_SIZE", () => {
+    // 25 raw todos that all normalize to just 2 unique topics:
+    // 15 raw rows for Topic A and 10 raw rows for Topic B.
+    const rawTodos: Array<TodoListItem> = [];
+
+    for (let i = 0; i < 15; i++) {
+      rawTodos.push(
+        makeTodoItem({
+          id: `topic-a-${i}`,
+          title: `Topic A ${i % 2 === 0 ? "!!" : ""}`,
+          created_at: `2026-01-01T${String(i).padStart(2, "0")}:00:00Z`,
+        })
+      );
+    }
+    for (let i = 0; i < 10; i++) {
+      rawTodos.push(
+        makeTodoItem({
+          id: `topic-b-${i}`,
+          title: `Topic B ${i % 2 === 0 ? "~~" : ""}`,
+          created_at: `2026-01-02T${String(i).padStart(2, "0")}:00:00Z`,
+        })
+      );
+    }
+
+    // 25 raw items grouped before pagination result in exactly 2 groups
+    const groups = groupTodosByTitle(rawTodos);
+    expect(groups).toHaveLength(2);
+
+    // Because there are only 2 groups, they fit completely on 1 page!
+    const { result } = renderHook(() => usePagination(groups, PAGE_SIZE));
+
+    expect(result.current.totalPages).toBe(1);
+    expect(result.current.pageRows).toHaveLength(2);
+    expect(result.current.pageRows[0].todoIds).toHaveLength(15);
+    expect(result.current.pageRows[1].todoIds).toHaveLength(10);
+  });
+
+  it("correctly slices grouped todos into pages when groups exceed PAGE_SIZE", () => {
+    // 15 distinct topics (15 groups)
+    const rawTodos = Array.from({ length: 15 }, (_, i) =>
+      makeTodoItem({
+        id: `id-${i}`,
+        title: `Distinct Topic ${i + 1}`,
+      })
+    );
+
+    const groups = groupTodosByTitle(rawTodos);
+    expect(groups).toHaveLength(15);
+
+    const { result } = renderHook(() => usePagination(groups, PAGE_SIZE));
+
+    // Page 1: exactly 10 groups
+    expect(result.current.page).toBe(1);
+    expect(result.current.totalPages).toBe(2);
+    expect(result.current.pageRows).toHaveLength(10);
+    expect(result.current.pageRows[0].title).toBe("Distinct Topic 1");
+    expect(result.current.pageRows[9].title).toBe("Distinct Topic 10");
+
+    // Navigate to Page 2
+    act(() => {
+      result.current.onNext();
+    });
+
+    expect(result.current.page).toBe(2);
+    expect(result.current.pageRows).toHaveLength(5);
+    expect(result.current.pageRows[0].title).toBe("Distinct Topic 11");
+    expect(result.current.pageRows[4].title).toBe("Distinct Topic 15");
+  });
+
+  it("guarantees every group appears exactly once across all pages", () => {
+    const rawTodos = Array.from({ length: 24 }, (_, i) =>
+      makeTodoItem({
+        id: `id-${i}`,
+        title: `Topic ${i + 1}`,
+      })
+    );
+
+    const groups = groupTodosByTitle(rawTodos);
+    const seenTitles = new Set<string>();
+
+    const totalPages = Math.ceil(groups.length / PAGE_SIZE);
+    expect(totalPages).toBe(3);
+
+    for (let p = 1; p <= totalPages; p++) {
+      const pageStart = (p - 1) * PAGE_SIZE;
+      const pageRows = groups.slice(pageStart, pageStart + PAGE_SIZE);
+
+      for (const row of pageRows) {
+        expect(seenTitles.has(row.title)).toBe(false); // No duplicate across pages
+        seenTitles.add(row.title);
+      }
+    }
+
+    expect(seenTitles.size).toBe(24);
+  });
+});

--- a/app/src/lib/__tests__/groupTodos.test.ts
+++ b/app/src/lib/__tests__/groupTodos.test.ts
@@ -2,9 +2,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { groupTodosByTitle } from "../groupTodos";
-import { usePagination } from "../usePagination";
 import type { TodoListItem } from "@bluelearn/schemas";
+import { groupTodosByTitle } from "@/lib/groupTodos";
+import { usePagination } from "@/lib/usePagination";
 
 function makeTodoItem(overrides: Partial<TodoListItem> = {}): TodoListItem {
   return {

--- a/app/src/lib/groupTodos.ts
+++ b/app/src/lib/groupTodos.ts
@@ -10,7 +10,7 @@ export type TodoGroup = {
   claimCount: number;
 };
 
-// Todo titles are free text, so the same topic can arrive as several rows spelled
+// titles of todos are free text, so the same topic can arrive as several rows spelled
 // differently. One card per normalized title and shows the first requester's
 // wording.
 export const groupTodosByTitle = (

--- a/app/src/routes/todos.tsx
+++ b/app/src/routes/todos.tsx
@@ -1,13 +1,19 @@
 import { useMemo } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { paginationSchema } from "@bluelearn/schemas";
 
 import { Separator } from "@/components/ui/separator";
 import { TodoCard } from "@/components/cards/TodoCard";
+import { Pagination } from "@/components/Pagination";
 
 import { listTodos } from "@/lib/api/todos";
 import { groupTodosByTitle } from "@/lib/groupTodos";
+import { usePagination } from "@/lib/usePagination";
+
+const PAGE_SIZE = 10;
 
 export const Route = createFileRoute("/todos")({
+  validateSearch: paginationSchema.pick({ page: true }),
   loader: ({ abortController }) =>
     listTodos({ signal: abortController.signal }),
   errorComponent: TodosLoadError,
@@ -47,9 +53,25 @@ const TodosPage = ({ children }: TodosPageProps) => {
 };
 
 function RouteComponent() {
+  const { page } = Route.useSearch();
   const todos = Route.useLoaderData();
+  const navigate = useNavigate();
 
   const groups = useMemo(() => groupTodosByTitle(todos), [todos]);
+
+  const {
+    page: activePage,
+    totalPages,
+    pageRows,
+    goToPage,
+    toFirst,
+    onPrevious,
+    onNext,
+    toLast,
+  } = usePagination(groups, PAGE_SIZE, {
+    page,
+    onPageChange: (p) => navigate({ to: "/todos", search: { page: p } }),
+  });
 
   if (groups.length === 0) {
     return (
@@ -64,10 +86,24 @@ function RouteComponent() {
   return (
     <TodosPage>
       <section className="grid gap-6 py-4 md:grid-cols-2">
-        {groups.map((group) => (
+        {pageRows.map((group) => (
           <TodoCard key={group.key} todo={group} />
         ))}
       </section>
+
+      {totalPages > 1 && (
+        <div className="mt-8 mb-4">
+          <Pagination
+            activePageNo={activePage}
+            onPageSelect={goToPage}
+            toFirst={toFirst}
+            onPrevious={onPrevious}
+            onNext={onNext}
+            toLast={toLast}
+            totalPages={totalPages}
+          />
+        </div>
+      )}
     </TodosPage>
   );
 }

--- a/app/src/routes/todos.tsx
+++ b/app/src/routes/todos.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { paginationSchema } from "@bluelearn/schemas";
 
 import { Separator } from "@/components/ui/separator";
@@ -78,6 +78,25 @@ function RouteComponent() {
       <TodosPage>
         <p className="text-sm text-muted-foreground">
           No todo guides right now.
+        </p>
+      </TodosPage>
+    );
+  }
+
+  // A hand-typed or stale page number lands past the end. Say so instead of
+  // showing the empty-state copy, which reads like there is nothing to browse.
+  if (page > totalPages) {
+    return (
+      <TodosPage>
+        <p className="text-sm text-muted-foreground">
+          Page {page} is past the last page.{" "}
+          <Link
+            to="/todos"
+            search={{ page: 1 }}
+            className="underline underline-offset-4"
+          >
+            Back to page 1
+          </Link>
         </p>
       </TodosPage>
     );

--- a/app/src/routes/todos.tsx
+++ b/app/src/routes/todos.tsx
@@ -5,6 +5,13 @@ import { paginationSchema } from "@bluelearn/schemas";
 import { Separator } from "@/components/ui/separator";
 import { TodoCard } from "@/components/cards/TodoCard";
 import { Pagination } from "@/components/Pagination";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 
 import { listTodos } from "@/lib/api/todos";
 import { groupTodosByTitle } from "@/lib/groupTodos";
@@ -76,9 +83,21 @@ function RouteComponent() {
   if (groups.length === 0) {
     return (
       <TodosPage>
-        <p className="text-sm text-muted-foreground">
-          No todo guides right now.
-        </p>
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia>
+              <img
+                src="/assets/adam/adam-cube-error.png"
+                alt="Adam mascot indicating no todo guides"
+                className="h-40 w-40 grayscale sm:h-56 sm:w-56"
+              />
+            </EmptyMedia>
+            <EmptyTitle className="data-label">No todo guides</EmptyTitle>
+            <EmptyDescription className="data-value">
+              No todo guides right now.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       </TodosPage>
     );
   }


### PR DESCRIPTION
## Summary

<!-- Required: Describe what changed and why. -->
Adds pagination to the Todo page ("Guides Waiting To Be Written") while preserving the existing todo grouping behavior.

e.g. changing `const PAGE_SIZE` in `todos.tsx` to 1 instead of 10;

<img width="1309" height="627" alt="image" src="https://github.com/user-attachments/assets/24a9ee93-8219-499d-85b5-13a45ea76064" />



Closes #374.


## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
