### PR TITLE
feat(app): Fetch guides when user selects them on multi-guide contribution page

### DIFF
--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -227,7 +227,7 @@ export default function ContributionFlow({
       }
 
       const convertedGuides: Array<MultiGuide> = [];
-      for (const [key, revision] of Object.entries(updated)) {
+      for (const revision of Object.values(updated)) {
         if (revision.type === "variant") continue;
 
         const converted = toMultiGuide(revision);

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -199,7 +199,6 @@ export default function ContributionFlow({
 
   useEffect(() => {
     function handleUpdate() {
-      console.log("handleUpdate()");
       function toMultiGuide(rev: LocalRevision): MultiGuide {
         return {
           type: rev.data.type === "" ? "theoretical" : rev.data.type,

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -221,16 +221,18 @@ export default function ContributionFlow({
         localStorage.getItem("bluelearn:contrib:drafts") || "{}"
       );
 
-      if (JSON.stringify(updated) === "{}") {
-        setGuideContData([]);
-      } else {
-        // Convert to Array<MultiGuide>
-        const convertedGuides: Array<MultiGuide> = [];
-        for (const [key, revision] of Object.entries(updated)) {
-          const converted = toMultiGuide(revision);
-          convertedGuides.push(converted);
-        }
+      const isEmpty = JSON.stringify(updated) === "{}";
+      if (isEmpty) {
+        setGuideContData([createMultiGuide()]);
+        return;
+      }
 
+      const convertedGuides: Array<MultiGuide> = [];
+      for (const [key, revision] of Object.entries(updated)) {
+        if (revision.type === "variant") continue;
+
+        const converted = toMultiGuide(revision);
+        convertedGuides.push(converted);
         setGuideContData(convertedGuides);
       }
     }

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -11,6 +11,7 @@ import type {
   VariantContribution,
 } from "@/types/contributions";
 
+import type { LocalRevision } from "@/lib/api/guideRevisions";
 import { MobileStepProgress } from "@/components/contribute/MobileStepProgress";
 
 import { SelectType } from "@/components/contribute/steps/SelectType";
@@ -195,6 +196,49 @@ export default function ContributionFlow({
 
     return [createMultiGuide()];
   });
+
+  useEffect(() => {
+    function handleUpdate() {
+      console.log("handleUpdate()");
+      function toMultiGuide(rev: LocalRevision): MultiGuide {
+        return {
+          type: rev.data.type === "" ? "theoretical" : rev.data.type,
+          title: rev.data.title,
+          summary: rev.data.summary,
+          body: rev.data.body,
+          subjects: rev.data.subjects.map((s) => s.id),
+          newSubjects: rev.data.newSubjects.map((name) => ({
+            name,
+            summary: "",
+          })),
+          prereqs: rev.data.prereqs,
+          todoPrereqs: rev.data.todoPrereqs,
+          localDraftId: rev.localDraftId,
+          revisionId: rev.revisionId,
+        };
+      }
+      const updated: Record<string, LocalRevision> = JSON.parse(
+        localStorage.getItem("bluelearn:contrib:drafts") || "{}"
+      );
+
+      if (JSON.stringify(updated) === "{}") {
+        setGuideContData([]);
+      } else {
+        // Convert to Array<MultiGuide>
+        const convertedGuides: Array<MultiGuide> = [];
+        for (const [key, revision] of Object.entries(updated)) {
+          const converted = toMultiGuide(revision);
+          convertedGuides.push(converted);
+        }
+
+        setGuideContData(convertedGuides);
+      }
+    }
+
+    window.addEventListener("existingDraftsAdded", handleUpdate);
+    return () =>
+      window.removeEventListener("existingDraftsAdded", handleUpdate);
+  }, []);
 
   const [activeGuideId, setActiveGuideId] = useState<string>(
     () => guideContData[0]?.localDraftId ?? ""

--- a/app/src/components/modals/SelectDraftModal.tsx
+++ b/app/src/components/modals/SelectDraftModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import type { LocalRevision, RemoteRevision } from "@/lib/api/guideRevisions";
 import {
   Dialog,
   DialogClose,
@@ -12,7 +13,10 @@ import {
 import { Combobox } from "@/components/ui/combobox";
 
 import { getGuideDrafts } from "@/lib/api/identity";
-import { getStoredDraftsByType } from "@/lib/contributionStorage";
+import {
+  createLocalDraftId,
+  getStoredDraftsByType,
+} from "@/lib/contributionStorage";
 import { Button } from "@/components/ui/button";
 import { getRevision } from "@/lib/api/guideRevisions";
 
@@ -89,17 +93,42 @@ export const SelectDraftModal = ({
   }, [open]);
 
   const fetchSelectedDrafts = async (draftIds: Array<string>) => {
-    // Fetch draft info given draft IDs from the database
-    const drafts = await Promise.all(
+    // Fetch revision info given draft IDs
+    const selected = await Promise.all(
       draftIds.map((draftId) => getRevision(draftId))
     );
 
-    return drafts;
+    return selected;
+  };
+
+  const toLocalDraft = (remote: RemoteRevision): LocalRevision => {
+    const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
+    return {
+      localDraftId: createLocalDraftId(),
+      type: "guide",
+      data: {
+        type: remote.knowledge_type ?? "",
+        title: remote.revision.title ?? "",
+        summary: remote.revision.summary ?? "",
+        body: remote.revision.body ?? "",
+        baseGuide: remote.revision.guide_id,
+        subjects: remote.subjects,
+        newSubjects: [],
+        prereqs: remote.prerequisites,
+        todoPrereqs: remote.todos,
+      },
+      revisionId: remote.revision.id,
+      step: "",
+      updatedAt: getCurrentUnixTime(),
+    };
   };
 
   const handleAddDrafts = async () => {
     onDraftsChange(selectedDrafts);
-    const drafts = await fetchSelectedDrafts(selectedDrafts);
+    const remoteDrafts: Array<RemoteRevision> =
+      await fetchSelectedDrafts(selectedDrafts);
+
+    const converted: Array<LocalRevision> = remoteDrafts.map(toLocalDraft);
 
     onOpenChange(false);
   };

--- a/app/src/components/modals/SelectDraftModal.tsx
+++ b/app/src/components/modals/SelectDraftModal.tsx
@@ -14,6 +14,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { getGuideDrafts } from "@/lib/api/identity";
 import { getStoredDraftsByType } from "@/lib/contributionStorage";
 import { Button } from "@/components/ui/button";
+import { getRevision } from "@/lib/api/guideRevisions";
 
 type GuideDraft = {
   revision_id: string;
@@ -87,8 +88,19 @@ export const SelectDraftModal = ({
     };
   }, [open]);
 
-  const handleAddDrafts = () => {
+  const fetchSelectedDrafts = async (draftIds: Array<string>) => {
+    // Fetch draft info given draft IDs from the database
+    const drafts = await Promise.all(
+      draftIds.map((draftId) => getRevision(draftId))
+    );
+
+    return drafts;
+  };
+
+  const handleAddDrafts = async () => {
     onDraftsChange(selectedDrafts);
+    const drafts = await fetchSelectedDrafts(selectedDrafts);
+
     onOpenChange(false);
   };
   const handleCancel = () => {

--- a/app/src/components/modals/SelectDraftModal.tsx
+++ b/app/src/components/modals/SelectDraftModal.tsx
@@ -146,6 +146,8 @@ export const SelectDraftModal = ({
 
     localStorage.setItem("bluelearn:contrib:drafts", JSON.stringify(draftJson));
 
+    window.dispatchEvent(new Event("existingDraftsAdded"));
+
     onOpenChange(false);
     setSelectedDrafts([]);
   };

--- a/app/src/components/modals/SelectDraftModal.tsx
+++ b/app/src/components/modals/SelectDraftModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 import type { LocalRevision, RemoteRevision } from "@/lib/api/guideRevisions";
 import {
@@ -33,6 +34,7 @@ type PropTypes = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   selectedDrafts: Array<string>;
+  setSelectedDrafts: Dispatch<SetStateAction<Array<string>>>;
   onDraftsChange: (draftIds: Array<string>) => void;
 };
 
@@ -40,6 +42,7 @@ export const SelectDraftModal = ({
   open,
   onOpenChange,
   selectedDrafts,
+  setSelectedDrafts,
   onDraftsChange,
 }: PropTypes) => {
   const [drafts, setDrafts] = useState<Array<GuideDraft>>([]);
@@ -102,6 +105,7 @@ export const SelectDraftModal = ({
   };
 
   const toLocalDraft = (remote: RemoteRevision): LocalRevision => {
+    // Convert remote drafts to local draft format
     const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
     return {
       localDraftId: createLocalDraftId(),
@@ -125,12 +129,25 @@ export const SelectDraftModal = ({
 
   const handleAddDrafts = async () => {
     onDraftsChange(selectedDrafts);
+
+    // Convert remote drafts to local draft format
     const remoteDrafts: Array<RemoteRevision> =
       await fetchSelectedDrafts(selectedDrafts);
 
     const converted: Array<LocalRevision> = remoteDrafts.map(toLocalDraft);
 
+    // Append to localStorage
+    const draftData = localStorage.getItem("bluelearn:contrib:drafts") ?? "{}";
+    const draftJson = JSON.parse(draftData);
+
+    for (const element of converted) {
+      draftJson[element.localDraftId] = element;
+    }
+
+    localStorage.setItem("bluelearn:contrib:drafts", JSON.stringify(draftJson));
+
     onOpenChange(false);
+    setSelectedDrafts([]);
   };
   const handleCancel = () => {
     onDraftsChange([]);

--- a/app/src/components/sidebar/EditorSidebar.tsx
+++ b/app/src/components/sidebar/EditorSidebar.tsx
@@ -219,6 +219,7 @@ export const EditorSidebar = ({
           open={selectDraftModalOpen}
           onOpenChange={setSelectDraftModalOpen}
           selectedDrafts={selectedDrafts}
+          setSelectedDrafts={setSelectedDrafts}
           onDraftsChange={handleSelectExistingDrafts}
         />
       )}

--- a/app/src/lib/__tests__/contributionStorage.test.ts
+++ b/app/src/lib/__tests__/contributionStorage.test.ts
@@ -9,11 +9,14 @@ import type {
 import {
   clearAllStoredDrafts,
   clearStoredDraft,
+  createLocalDraftId,
   getStoredDraft,
   hasStoredDraft,
   setStoredDraft,
   useDebouncedContributionSave,
 } from "@/lib/contributionStorage";
+
+const STORAGE_KEY = "bluelearn:contrib:drafts";
 
 const createLocalStorageMock = () => {
   let store: Record<string, string> = {};
@@ -31,6 +34,37 @@ const createLocalStorageMock = () => {
   };
 };
 
+const sampleGuide: GuideContribution = {
+  type: "theoretical",
+  title: "Understanding Persistent State",
+  summary: "A short summary",
+  body: "# Markdown Content",
+  subjects: ["sub-1"],
+  newSubjects: [],
+  prereqs: [],
+  todoPrereqs: [],
+};
+
+const sampleVariant: VariantContribution = {
+  type: "theoretical",
+  title: "Variant Draft",
+  summary: "A short summary",
+  baseGuide: "base-guide-slug",
+  subjects: ["sub-1"],
+  newSubjects: [],
+  body: "# Markdown Content",
+};
+
+const sampleObjective: ObjectiveContribution = {
+  title: "Objective Draft",
+  summary: "A short summary",
+  changeSummary: "Initial draft",
+  targets: ["target-1"],
+  featuredSubObjective: "sub-obj-1",
+  subObjectives: [],
+  subjects: ["sub-1"],
+};
+
 describe("contributionStorage", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -46,27 +80,20 @@ describe("contributionStorage", () => {
   });
 
   it("saves and retrieves a guide draft from localStorage", () => {
-    const sampleGuide: GuideContribution = {
-      type: "theoretical",
-      title: "Understanding Persistent State",
-      summary: "A short summary",
-      body: "# Markdown Content",
-      subjects: ["sub-1"],
-      newSubjects: [],
-      prereqs: [],
-      todoPrereqs: [],
-    };
+    const localDraftId = createLocalDraftId();
 
-    setStoredDraft("guide", {
+    setStoredDraft({
+      localDraftId,
+      type: "guide",
       data: sampleGuide,
       revisionId: "rev-123",
       step: "guide-details",
       updatedAt: Date.now(),
     });
 
-    expect(hasStoredDraft("guide")).toBe(true);
+    expect(hasStoredDraft(localDraftId)).toBe(true);
 
-    const stored = getStoredDraft<GuideContribution>("guide");
+    const stored = getStoredDraft(localDraftId, "guide");
     expect(stored).not.toBeNull();
     expect(stored?.data.title).toBe("Understanding Persistent State");
     expect(stored?.revisionId).toBe("rev-123");
@@ -74,55 +101,73 @@ describe("contributionStorage", () => {
   });
 
   it("clears a stored draft", () => {
-    setStoredDraft("variant", {
-      data: {} as VariantContribution,
+    const localDraftId = createLocalDraftId();
+
+    setStoredDraft({
+      localDraftId,
+      type: "variant",
+      data: sampleVariant,
       revisionId: null,
       updatedAt: Date.now(),
     });
 
-    expect(hasStoredDraft("variant")).toBe(true);
-    clearStoredDraft("variant");
-    expect(hasStoredDraft("variant")).toBe(false);
-    expect(getStoredDraft("variant")).toBeNull();
+    expect(hasStoredDraft(localDraftId)).toBe(true);
+
+    clearStoredDraft(localDraftId);
+
+    expect(hasStoredDraft(localDraftId)).toBe(false);
+    expect(getStoredDraft(localDraftId, "variant")).toBeNull();
   });
 
   it("clears all stored drafts with clearAllStoredDrafts", () => {
-    setStoredDraft("guide", {
-      data: { title: "Guide Draft" } as GuideContribution,
+    const guideId = createLocalDraftId();
+    const variantId = createLocalDraftId();
+    const objectiveId = createLocalDraftId();
+
+    setStoredDraft({
+      localDraftId: guideId,
+      type: "guide",
+      data: sampleGuide,
       revisionId: "rev-g",
       updatedAt: Date.now(),
     });
-    setStoredDraft("variant", {
-      data: { title: "Variant Draft" } as VariantContribution,
+    setStoredDraft({
+      localDraftId: variantId,
+      type: "variant",
+      data: sampleVariant,
       revisionId: "rev-v",
       updatedAt: Date.now(),
     });
-    setStoredDraft("objective", {
-      data: { title: "Objective Draft" } as ObjectiveContribution,
+    setStoredDraft({
+      localDraftId: objectiveId,
+      type: "objective",
+      data: sampleObjective,
       revisionId: "rev-o",
       updatedAt: Date.now(),
     });
 
-    expect(hasStoredDraft("guide")).toBe(true);
-    expect(hasStoredDraft("variant")).toBe(true);
-    expect(hasStoredDraft("objective")).toBe(true);
+    expect(hasStoredDraft(guideId)).toBe(true);
+    expect(hasStoredDraft(variantId)).toBe(true);
+    expect(hasStoredDraft(objectiveId)).toBe(true);
 
     clearAllStoredDrafts();
 
-    expect(hasStoredDraft("guide")).toBe(false);
-    expect(hasStoredDraft("variant")).toBe(false);
-    expect(hasStoredDraft("objective")).toBe(false);
-    expect(getStoredDraft("guide")).toBeNull();
-    expect(getStoredDraft("variant")).toBeNull();
-    expect(getStoredDraft("objective")).toBeNull();
+    expect(hasStoredDraft(guideId)).toBe(false);
+    expect(hasStoredDraft(variantId)).toBe(false);
+    expect(hasStoredDraft(objectiveId)).toBe(false);
+    expect(getStoredDraft(guideId, "guide")).toBeNull();
+    expect(getStoredDraft(variantId, "variant")).toBeNull();
+    expect(getStoredDraft(objectiveId, "objective")).toBeNull();
   });
 
   it("safely handles corrupted JSON in localStorage", () => {
-    window.localStorage.setItem("bluelearn:contrib:guide", "{invalid-json");
-    expect(getStoredDraft("guide")).toBeNull();
+    window.localStorage.setItem(STORAGE_KEY, "{invalid-json");
+    expect(getStoredDraft(createLocalDraftId(), "guide")).toBeNull();
   });
 
   it("debounces saves and flushes pending changes on unmount", () => {
+    const localDraftId = createLocalDraftId();
+
     const initialData: GuideContribution = {
       type: "theoretical",
       title: "Draft Initial",
@@ -136,7 +181,14 @@ describe("contributionStorage", () => {
 
     const { rerender, unmount } = renderHook(
       ({ data, step }: { data: GuideContribution; step?: string }) =>
-        useDebouncedContributionSave("guide", data, "rev-1", step, 300),
+        useDebouncedContributionSave(
+          localDraftId,
+          "guide",
+          data,
+          "rev-1",
+          step,
+          300
+        ),
       {
         initialProps: {
           data: initialData,
@@ -146,15 +198,15 @@ describe("contributionStorage", () => {
     );
 
     // Initial render should not have written immediately before timer
-    expect(hasStoredDraft("guide")).toBe(false);
+    expect(hasStoredDraft(localDraftId)).toBe(false);
 
     // Advance timer past delay
     act(() => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(hasStoredDraft("guide")).toBe(true);
-    expect(getStoredDraft<GuideContribution>("guide")?.data.title).toBe(
+    expect(hasStoredDraft(localDraftId)).toBe(true);
+    expect(getStoredDraft(localDraftId, "guide")?.data.title).toBe(
       "Draft Initial"
     );
 
@@ -172,7 +224,7 @@ describe("contributionStorage", () => {
     act(() => {
       vi.advanceTimersByTime(100);
     });
-    expect(getStoredDraft<GuideContribution>("guide")?.data.title).toBe(
+    expect(getStoredDraft(localDraftId, "guide")?.data.title).toBe(
       "Draft Initial"
     );
 
@@ -188,7 +240,7 @@ describe("contributionStorage", () => {
     // Unmount before timer finishes flushes pending changes
     unmount();
 
-    const stored = getStoredDraft<GuideContribution>("guide");
+    const stored = getStoredDraft(localDraftId, "guide");
     expect(stored?.data.title).toBe("Draft Update 2");
     expect(stored?.step).toBe("content");
   });

--- a/app/src/lib/api/guideRevisions.ts
+++ b/app/src/lib/api/guideRevisions.ts
@@ -1,4 +1,5 @@
 import type { InferRequestType } from "hono/client";
+import type { UUID } from "node:crypto";
 import { client } from "@/lib/api/apiClient";
 import { assertOk } from "@/lib/api/apiHelpers";
 
@@ -6,7 +7,68 @@ const revisions = client["guide-revisions"];
 
 type FetchOptions = { signal?: AbortSignal };
 
-export async function getRevision(id: string, { signal }: FetchOptions = {}) {
+export type RemoteRevision = {
+  revision: {
+    id: string;
+    guide_id: string;
+    title: string | null;
+    summary: string | null;
+    body: string | null;
+    change_summary: string | null;
+    status: "draft" | "submitted";
+    created_at: string;
+  };
+  subjects: Array<{
+    id: string;
+    slug: string | null;
+    name: string;
+    summary: string | null;
+    status: "draft" | "published";
+  }>;
+  knowledge_type: "theoretical" | "practical" | null;
+  is_variant: boolean;
+  base_slug: string | null;
+  variant_slug: string | null;
+  prerequisites: Array<string>;
+  todos: Array<{
+    title: string;
+    summary: string;
+  }>;
+  revised_from_case_id: string | null;
+};
+
+export type LocalRevision = {
+  localDraftId: UUID;
+  type: "variant" | "guide" | "";
+  data: {
+    type: "theoretical" | "practical" | "";
+    title: string;
+    summary: string;
+    baseGuide: string;
+    body: string;
+    subjects: Array<{
+      id: string;
+      slug: string | null;
+      name: string;
+      summary: string | null;
+      status: "draft" | "published";
+    }>;
+    newSubjects: Array<string>;
+    prereqs: Array<string>;
+    todoPrereqs: Array<{
+      title: string;
+      summary: string;
+    }>;
+  };
+  revisionId: string;
+  step: string;
+  updatedAt: number;
+};
+
+export async function getRevision(
+  id: string,
+  { signal }: FetchOptions = {}
+): Promise<RemoteRevision> {
   const res = await revisions[":id"].$get(
     { param: { id } },
     { init: { signal } }

--- a/app/src/lib/contributionStorage.ts
+++ b/app/src/lib/contributionStorage.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { z } from "zod";
 import type { ContributionType } from "@/types/contributions";
+import type { UUID } from "node:crypto";
 import {
   guideContributionSchema,
   objectiveContributionSchema,
@@ -124,7 +125,7 @@ function writeStoredDrafts(drafts: StoredDrafts): void {
 }
 
 // generates a unique ID for new local draft
-export function createLocalDraftId(): string {
+export function createLocalDraftId(): UUID {
   if (
     typeof crypto !== "undefined" &&
     typeof crypto.randomUUID === "function"


### PR DESCRIPTION
## Summary

Fetches guides that the user selects from the `SelectDraftModal`.

This PR merges into the `feat/allow-multi-guide-contributions` branch. It builds on top of PR #387.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [x] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
