### PR TITLE
fix(db): use user status to check for eligible verifiers

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -83,11 +83,10 @@ async function scheduled(event: ScheduledController, env: Bindings) {
   );
 
   if (event.cron === "*/5 * * * *") {
-    const results = await Promise.allSettled([
+    await Promise.allSettled([
       assemblePendingPanels(supabase),
       sweepExpiredReviewSeats(supabase),
     ]);
-    console.log(results);
   }
   if (event.cron === "0 */12 * * *") await promoteAllCanonicals(supabase);
 }

--- a/supabase/migrations/20260907133031_use_status_in_panel_fns.sql
+++ b/supabase/migrations/20260907133031_use_status_in_panel_fns.sql
@@ -1,0 +1,29 @@
+create or replace function public.eligible_panel_verifiers(
+  p_created_by uuid,
+  p_panel_id uuid default null
+)
+returns table (id uuid)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select us.user_id
+    from public.user_roles ur
+    join public.user_statuses us on us.user_id = ur.user_id
+    where ur.role = 'verifier'
+      and us.status = 'active'
+      and us.user_id is distinct from p_created_by
+      and (
+        p_panel_id is null
+        or not exists (
+          select 1
+            from public.panel_members pm
+            where pm.panel_id = p_panel_id
+              and pm.member_id = us.user_id
+        )
+      );
+$$;
+
+revoke execute on function public.eligible_panel_verifiers(uuid, uuid) from public;
+grant execute on function public.eligible_panel_verifiers(uuid, uuid) to service_role;


### PR DESCRIPTION
## Summary

When checking for eligible verifiers, a user's status is now checked, instead of whether they are suspended. Removed an extraneous console.log that never logged anything.
( Closes #404 )  

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

- [X] `pnpm -r typecheck` passes
- [X] `pnpm -r build` passes
- [X] Manually verified in a browser (for UI / behavior changes)
- [X] Followed the app layout conventions
- [X] No new dependencies, or new dependencies are justified and AGPL-compatible
- [X] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required [N/A]
