### PR TITLE
feat(api): gate todo claims to one open submission

### DIFF
--- a/api/src/database.types.ts
+++ b/api/src/database.types.ts
@@ -1345,6 +1345,10 @@ export type Database = {
         Args: { p_revision_id: string }
         Returns: string
       }
+      todo_has_open_claim: {
+        Args: { p_todo_ids: string[]; p_exclude_base_id: string }
+        Returns: boolean
+      }
       sweep_expired_review_seats: { Args: never; Returns: Json }
       wilson_lower_bound: {
         Args: { downvotes: number; upvotes: number; z?: number }

--- a/api/src/routes/guides.ts
+++ b/api/src/routes/guides.ts
@@ -623,7 +623,7 @@ export const guideRevisionsRouter = new Hono<HonoEnv>()
       security: [{ bearerAuth: [] }],
       responses: {
         201: jsonContent(reviewCaseIdResponseSchema, "Review case opened"),
-        ...errorResponses(400, 401, 404, 422, 429),
+        ...errorResponses(400, 401, 404, 409, 422, 429),
       },
     }),
     requireUser,

--- a/api/src/services/guide-revision.service.ts
+++ b/api/src/services/guide-revision.service.ts
@@ -471,10 +471,58 @@ export async function updateRevision(
   return { revision, subjects };
 }
 
+// 409 the submit when rival claim is pending/in review.
+async function assertNoCompetingTodoClaim(supabase: DB, revisionId: string) {
+  const { data: rev, error: revError } = await supabase
+    .from("guide_revisions")
+    .select("guide_id")
+    .eq("id", revisionId)
+    .maybeSingle();
+  if (revError || !rev) return;
+
+  const { data: guide, error: guideError } = await supabase
+    .from("guides")
+    .select("guide_base_id")
+    .eq("id", rev.guide_id)
+    .maybeSingle();
+  if (guideError || !guide) return;
+
+  const { data: claims, error: claimsError } = await supabase
+    .from("todo_claims")
+    .select("todo_id")
+    .eq("guide_base_id", guide.guide_base_id);
+  if (claimsError) throw new ServiceError("Unable to submit revision", 400);
+  const todoIds = (claims ?? []).map((c) => c.todo_id);
+  if (todoIds.length === 0) return;
+
+  const { data: todos, error: todosError } = await supabase
+    .from("todo_prerequisites")
+    .select("status")
+    .in("id", todoIds);
+  if (todosError) throw new ServiceError("Unable to submit revision", 400);
+  if ((todos ?? []).some((t) => t.status !== "open")) {
+    throw new ServiceError("This todo has already been fulfilled", 409);
+  }
+
+  const { data: blocked, error: gateError } = await supabase.rpc(
+    "todo_has_open_claim",
+    { p_todo_ids: todoIds, p_exclude_base_id: guide.guide_base_id }
+  );
+  if (gateError) throw new ServiceError("Unable to submit revision", 400);
+  if (blocked) {
+    throw new ServiceError(
+      "Another guide claiming this todo is already in review",
+      409
+    );
+  }
+}
+
 // Submit a draft for review: flips it to submitted, opens a review case, and
 // links the two in one transaction via the submit_guide_revision RPC (RLS still
 // applies). Returns the opened review case id.
 export async function submitRevision(supabase: DB, id: string) {
+  await assertNoCompetingTodoClaim(supabase, id);
+
   const { data: review_case_id, error } = await supabase.rpc(
     "submit_guide_revision",
     {

--- a/api/src/services/guide-revision.service.ts
+++ b/api/src/services/guide-revision.service.ts
@@ -475,22 +475,20 @@ export async function updateRevision(
 async function assertNoCompetingTodoClaim(supabase: DB, revisionId: string) {
   const { data: rev, error: revError } = await supabase
     .from("guide_revisions")
-    .select("guide_id")
+    .select(
+      "guide_id, guides!guide_revisions_guide_id_fkey!inner(guide_base_id)"
+    )
     .eq("id", revisionId)
     .maybeSingle();
-  if (revError || !rev) return;
-
-  const { data: guide, error: guideError } = await supabase
-    .from("guides")
-    .select("guide_base_id")
-    .eq("id", rev.guide_id)
-    .maybeSingle();
-  if (guideError || !guide) return;
+  if (revError || !rev) {
+    throw new ServiceError("Revision not found or not an editable draft", 404);
+  }
+  const baseId = rev.guides.guide_base_id;
 
   const { data: claims, error: claimsError } = await supabase
     .from("todo_claims")
     .select("todo_id")
-    .eq("guide_base_id", guide.guide_base_id);
+    .eq("guide_base_id", baseId);
   if (claimsError) throw new ServiceError("Unable to submit revision", 400);
   const todoIds = (claims ?? []).map((c) => c.todo_id);
   if (todoIds.length === 0) return;
@@ -506,7 +504,7 @@ async function assertNoCompetingTodoClaim(supabase: DB, revisionId: string) {
 
   const { data: blocked, error: gateError } = await supabase.rpc(
     "todo_has_open_claim",
-    { p_todo_ids: todoIds, p_exclude_base_id: guide.guide_base_id }
+    { p_todo_ids: todoIds, p_exclude_base_id: baseId }
   );
   if (gateError) throw new ServiceError("Unable to submit revision", 400);
   if (blocked) {

--- a/api/tests/guide-revisions.test.ts
+++ b/api/tests/guide-revisions.test.ts
@@ -433,6 +433,104 @@ describe("POST /guide-revisions/{id}/submit", () => {
     expect(res.status).toBe(404);
     await expectToMatchSpec(res, "POST", "/guide-revisions/{id}/submit");
   });
+
+  it("409s when another open review claims the same todo", async () => {
+    const authorA = await makeUser();
+    const { revision: revA, base: baseA } = await createCompleteDraft(
+      authorA.userId
+    );
+    const todo = await createTodo(baseA.id);
+    await admin
+      .from("todo_claims")
+      .insert({ todo_id: todo.id, guide_base_id: baseA.id })
+      .throwOnError();
+    const first = await app.request(
+      `/guide-revisions/${revA.id}/submit`,
+      { method: "POST", ...auth(authorA.token) },
+      env
+    );
+    expect(first.status).toBe(201);
+
+    const authorB = await makeUser();
+    const { revision: revB, base: baseB } = await createCompleteDraft(
+      authorB.userId
+    );
+    await admin
+      .from("todo_claims")
+      .insert({ todo_id: todo.id, guide_base_id: baseB.id })
+      .throwOnError();
+    const res = await app.request(
+      `/guide-revisions/${revB.id}/submit`,
+      { method: "POST", ...auth(authorB.token) },
+      env
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("409s when the claimed todo was already fulfilled", async () => {
+    const author = await makeUser();
+    const { revision, base } = await createCompleteDraft(author.userId);
+    const todo = await createTodo(base.id);
+    await admin
+      .from("todo_claims")
+      .insert({ todo_id: todo.id, guide_base_id: base.id })
+      .throwOnError();
+    await admin
+      .from("todo_prerequisites")
+      .update({ status: "resolved", resolved_guide_base_id: base.id })
+      .eq("id", todo.id)
+      .throwOnError();
+    const res = await app.request(
+      `/guide-revisions/${revision.id}/submit`,
+      { method: "POST", ...auth(author.token) },
+      env
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("allows submit once the competing claim was rejected", async () => {
+    const authorA = await makeUser();
+    const { revision: revA, base: baseA } = await createCompleteDraft(
+      authorA.userId
+    );
+    const todo = await createTodo(baseA.id);
+    await admin
+      .from("todo_claims")
+      .insert({ todo_id: todo.id, guide_base_id: baseA.id })
+      .throwOnError();
+    const first = await app.request(
+      `/guide-revisions/${revA.id}/submit`,
+      { method: "POST", ...auth(authorA.token) },
+      env
+    );
+    expect(first.status).toBe(201);
+    const { review_case_id } = (await first.json()) as {
+      review_case_id: string;
+    };
+    await admin
+      .from("review_cases")
+      .update({ status: "rejected" })
+      .eq("id", review_case_id)
+      .throwOnError();
+
+    const authorB = await makeUser();
+    const { revision: revB, base: baseB } = await createCompleteDraft(
+      authorB.userId
+    );
+    await admin
+      .from("todo_claims")
+      .insert({ todo_id: todo.id, guide_base_id: baseB.id })
+      .throwOnError();
+    const res = await app.request(
+      `/guide-revisions/${revB.id}/submit`,
+      { method: "POST", ...auth(authorB.token) },
+      env
+    );
+
+    expect(res.status).toBe(201);
+  });
 });
 
 describe("POST /guide-revisions/{id}/revise", () => {

--- a/supabase/migrations/20260908120000_todo_open_claim_gate.sql
+++ b/supabase/migrations/20260908120000_todo_open_claim_gate.sql
@@ -1,0 +1,22 @@
+-- Activates when another base has a todo still pending/being reviewed.
+-- Security definer lets gate see rival drafts the caller can't.
+create or replace function public.todo_has_open_claim(p_todo_ids uuid[], p_exclude_base_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+      from public.todo_claims tc
+      join public.guides g on g.guide_base_id = tc.guide_base_id
+      join public.guide_revisions gr on gr.guide_id = g.id
+      join public.guide_review_cases grc on grc.guide_revision_id = gr.id
+      join public.review_cases rc on rc.id = grc.case_id
+     where tc.todo_id = any (p_todo_ids)
+       and tc.guide_base_id <> p_exclude_base_id
+       and rc.status in ('pending', 'in_review')
+  );
+$$;
+
+grant execute on function public.todo_has_open_claim(uuid[], uuid) to authenticated;


### PR DESCRIPTION
## Summary

Gate guide submits to one open submission per todo. 

Closes #346.

## Type of change

<!-- Check the ONE that best describes this change. -->

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / tooling / CI
- [ ] Other: _________

## Verification

<!-- Update checkboxes based on what verification methods were completed. -->

- [x] `pnpm -r typecheck` passes
- [ ] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle
- [ ] Documentation only, no changes to the codebase, so no tests required
