### PR TITLE
feat(app): show todo prerequisites in guides

### DIFF
--- a/api/src/services/guide.service.ts
+++ b/api/src/services/guide.service.ts
@@ -7,6 +7,7 @@ import type {
   GuideReference,
   Pagination,
   SubjectReference,
+  TodoPrerequisiteReference,
   Walkthrough,
 } from "@bluelearn/schemas";
 import type { Database } from "../database.types";
@@ -280,6 +281,31 @@ async function loadPrerequisites(
     .sort((a, b) => a.title.localeCompare(b.title));
 }
 
+// Requested prerequisites that haven't been resolved yet.
+async function loadTodoPrerequisites(
+  supabase: DB,
+  baseId: string
+): Promise<TodoPrerequisiteReference[]> {
+  const { data, error } = await supabase
+    .from("todo_prerequisites")
+    .select("id, title, summary")
+    .eq("dependent_guide_base_id", baseId)
+    .eq("status", "open");
+
+  if (error) {
+    console.error(error);
+    throw new ServiceError("Failed to load todo prerequisites", 500);
+  }
+
+  return (data ?? [])
+    .map((todo) => ({
+      id: todo.id,
+      title: todo.title,
+      summary: todo.summary,
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+}
+
 export async function getGuideBySlug(supabase: DB, rawSlug: string) {
   const slug = rawSlug.toLowerCase();
 
@@ -299,11 +325,13 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
 
   const canonical = guide.canonical;
   const current = canonical?.current ?? null;
-  const [subjects, prerequisites, disclaimers] = await Promise.all([
-    loadCanonicalTags(supabase, current?.id ?? null),
-    loadPrerequisites(supabase, guide.id),
-    loadDisclaimers(supabase, guide.id),
-  ]);
+  const [subjects, prerequisites, todoPrerequisites, disclaimers] =
+    await Promise.all([
+      loadCanonicalTags(supabase, current?.id ?? null),
+      loadPrerequisites(supabase, guide.id),
+      loadTodoPrerequisites(supabase, guide.id),
+      loadDisclaimers(supabase, guide.id),
+    ]);
   const authorId = canonical?.author_id ?? null;
   const usernames = await loadUsernames(supabase, [authorId]);
 
@@ -320,6 +348,7 @@ export async function getGuideBySlug(supabase: DB, rawSlug: string) {
     created_at: guide.created_at,
     tags: subjects.map((s) => ({ slug: s.slug, name: s.name })),
     prerequisites,
+    todo_prerequisites: todoPrerequisites,
     is_official: guide.is_official,
     disclaimers,
   };

--- a/api/tests/guides.test.ts
+++ b/api/tests/guides.test.ts
@@ -10,7 +10,7 @@ import {
   createVote,
 } from "./factories/guides";
 import { createSubject, tagGuideRevision } from "./factories/subjects";
-import { createPrerequisite } from "./factories/graph";
+import { createPrerequisite, createTodo } from "./factories/graph";
 import { expectToMatchSpec } from "./openapi";
 
 describe("GET /guides", () => {
@@ -153,10 +153,50 @@ describe("GET /guides/{slug}", () => {
       slug: string;
       body: string | null;
       tags: Array<{ slug: string }>;
+      todo_prerequisites: unknown[];
     };
     expect(body.slug).toBe(base.slug);
     expect(body.body).toBe("Content");
     expect(body.tags.map((t) => t.slug)).toContain(subject.slug);
+    expect(body.todo_prerequisites).toEqual([]);
+  });
+
+  it("returns sorted open todos for this guide and omits resolved ones", async () => {
+    const { base } = await createPublishedGuide();
+    const open = await createTodo(base.id, { title: "Learn limits" });
+    const earlier = await createTodo(base.id, { title: "Learn algebra" });
+    const resolver = await createPublishedGuide();
+    await createTodo(resolver.base.id, { title: "Another guide's todo" });
+    await createPrerequisite(resolver.base.id, base.id);
+    await createTodo(base.id, {
+      title: "Learn derivatives",
+      status: "resolved",
+      resolved_guide_base_id: resolver.base.id,
+    });
+
+    const res = await app.request(`/guides/${base.slug}`, {}, env);
+
+    expect(res.status).toBe(200);
+    await expectToMatchSpec(res, "GET", "/guides/{slug}");
+    const body = (await res.json()) as {
+      todo_prerequisites: Array<{ id: string; title: string; summary: string }>;
+      prerequisites: Array<{ slug: string; title: string }>;
+    };
+    expect(body.todo_prerequisites).toEqual([
+      {
+        id: earlier.id,
+        title: "Learn algebra",
+        summary: "What the missing prerequisite should cover",
+      },
+      {
+        id: open.id,
+        title: "Learn limits",
+        summary: "What the missing prerequisite should cover",
+      },
+    ]);
+    expect(body.prerequisites).toEqual([
+      expect.objectContaining({ slug: resolver.base.slug }),
+    ]);
   });
 
   it("names the canonical variant so callers can build its permalink", async () => {

--- a/app/src/components/GuideMobileMenu.tsx
+++ b/app/src/components/GuideMobileMenu.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { Ellipsis, ListChecks } from "lucide-react";
-import type { GuideReference } from "@bluelearn/schemas";
+import type {
+  GuideReference,
+  TodoPrerequisiteReference,
+} from "@bluelearn/schemas";
 
 import type { GuideModalType } from "@/components/GuideActionModals";
 import { Button } from "@/components/ui/button";
@@ -25,6 +28,7 @@ type GuideMobileMenuProps = {
   guideTitle: string;
   menuItems: Array<{ label: string; to: string; icon: React.ReactNode }>;
   prerequisites?: Array<GuideReference>;
+  todoPrerequisites?: Array<TodoPrerequisiteReference>;
   isOfficial?: boolean;
 };
 
@@ -35,6 +39,7 @@ export function GuideMobileMenu({
   guideTitle,
   menuItems,
   prerequisites,
+  todoPrerequisites = [],
   isOfficial = false,
 }: GuideMobileMenuProps) {
   const [activeModal, setActiveModal] = useState<
@@ -105,6 +110,7 @@ export function GuideMobileMenu({
           open={activeModal === "prerequisites"}
           onOpenChange={close}
           prerequisites={prerequisites}
+          todoPrerequisites={todoPrerequisites}
           guideTitle={guideTitle}
           slug={slug}
         />

--- a/app/src/components/__tests__/prerequisites.test.tsx
+++ b/app/src/components/__tests__/prerequisites.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type {
+  Guide,
+  GuideReference,
+  TodoPrerequisiteReference,
+} from "@bluelearn/schemas";
+import { GuideSidebar } from "@/components/sidebar/GuideSidebar";
+import { PrerequisitesModal } from "@/components/modals/PrerequisitesModal";
+
+// Keep link destinations visible without mounting the application router.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    params,
+    onClick,
+  }: {
+    children: ReactNode;
+    params: { slug: string };
+    onClick?: () => void;
+  }) => (
+    <a
+      href={`/guides/${params.slug}`}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.();
+      }}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+const prerequisite: GuideReference = { slug: "variables", title: "Variables" };
+const todo: TodoPrerequisiteReference = {
+  id: "20000000-0000-4000-8000-000000000001",
+  title: "Loop invariants",
+  summary: "How to reason about each iteration of a loop.",
+};
+
+function makeGuide(
+  prerequisites: Array<GuideReference>,
+  todos: Array<TodoPrerequisiteReference>
+): Guide {
+  return {
+    slug: "binary-search",
+    variant_id: null,
+    variant_slug: null,
+    title: "Binary search",
+    author: null,
+    knowledge_type: "theoretical",
+    summary: null,
+    body: "",
+    duration_minutes: 0,
+    created_at: "2026-09-10T00:00:00Z",
+    tags: [],
+    prerequisites,
+    todo_prerequisites: todos,
+    is_official: false,
+    disclaimers: [],
+  };
+}
+
+afterEach(cleanup);
+
+describe.each(["sidebar", "mobile dialog"] as const)(
+  "%s prerequisites",
+  (surface) => {
+    function show(
+      prerequisites: Array<GuideReference>,
+      todos: Array<TodoPrerequisiteReference>
+    ) {
+      return render(
+        surface === "sidebar" ? (
+          <GuideSidebar
+            guide={makeGuide(prerequisites, todos)}
+            slug="binary-search"
+          />
+        ) : (
+          <PrerequisitesModal
+            open
+            onOpenChange={() => {}}
+            prerequisites={prerequisites}
+            todoPrerequisites={todos}
+            guideTitle="Binary search"
+            slug="binary-search"
+          />
+        )
+      );
+    }
+
+    it("shows the empty state when neither kind is present", () => {
+      show([], []);
+      expect(screen.getByText("None declared")).toBeDefined();
+      expect(screen.queryByText("Todo")).toBeNull();
+    });
+
+    it("shows a todo without a link when there are no existing prerequisites", () => {
+      show([], [todo]);
+      expect(screen.queryByText("None declared")).toBeNull();
+      expect(screen.getByText(todo.title).closest("a")).toBeNull();
+      expect(screen.getByText("Todo")).toBeDefined();
+      if (surface === "mobile dialog") {
+        expect(screen.getByText(todo.summary)).toBeDefined();
+      } else {
+        expect(screen.getByText(todo.title).closest("li")?.title).toBe(
+          todo.summary
+        );
+      }
+    });
+
+    it("keeps existing prerequisites as links alongside todos", () => {
+      show([prerequisite], [todo]);
+      expect(
+        screen.getByRole("link", { name: "Variables" }).getAttribute("href")
+      ).toBe("/guides/variables");
+      expect(screen.getByText(todo.title).closest("a")).toBeNull();
+      expect(screen.queryByText("None declared")).toBeNull();
+    });
+  }
+);
+
+it("accepts older guide responses without the todo field", () => {
+  const guide = makeGuide([prerequisite], []);
+  Reflect.deleteProperty(guide, "todo_prerequisites");
+  render(<GuideSidebar guide={guide} slug="binary-search" />);
+  expect(screen.getByRole("link", { name: "Variables" })).toBeDefined();
+});
+
+it("keeps prerequisites hidden on variant pages", () => {
+  render(
+    <GuideSidebar
+      guide={makeGuide([prerequisite], [todo])}
+      slug="binary-search"
+      showPrerequisites={false}
+    />
+  );
+  expect(screen.queryByText("Prerequisites")).toBeNull();
+  expect(screen.queryByText(todo.title)).toBeNull();
+});
+
+it("closes the mobile dialog when an existing prerequisite is selected", () => {
+  const onOpenChange = vi.fn();
+  render(
+    <PrerequisitesModal
+      open
+      onOpenChange={onOpenChange}
+      prerequisites={[prerequisite]}
+      todoPrerequisites={[todo]}
+      guideTitle="Binary search"
+      slug="binary-search"
+    />
+  );
+  fireEvent.click(screen.getByRole("link", { name: "Variables" }));
+  expect(onOpenChange).toHaveBeenCalledWith(false);
+});

--- a/app/src/components/contribute/ContributionFlow.tsx
+++ b/app/src/components/contribute/ContributionFlow.tsx
@@ -554,6 +554,7 @@ function Inner({
         title: titleBySlug.get(slug) ?? slug,
       })),
       disclaimers: guideContData.disclaimers,
+      todo_prerequisites: [],
     };
   }, [guideContData, subjectOptions, guideOptions, username]);
 
@@ -584,6 +585,7 @@ function Inner({
       ],
       prerequisites: [],
       disclaimers: [],
+      todo_prerequisites: [],
     };
   }, [variantContData, subjectOptions, username]);
 

--- a/app/src/components/modals/PrerequisitesModal.tsx
+++ b/app/src/components/modals/PrerequisitesModal.tsx
@@ -1,12 +1,17 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, ListChecks } from "lucide-react";
 import { BaseGuideModal } from "./BaseGuideModal";
-import type { GuideReference } from "@bluelearn/schemas";
+import type {
+  GuideReference,
+  TodoPrerequisiteReference,
+} from "@bluelearn/schemas";
+import { Badge } from "@/components/ui/badge";
 
 type PrerequisitesModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   prerequisites: Array<GuideReference>;
+  todoPrerequisites: Array<TodoPrerequisiteReference>;
   guideTitle: string;
   slug: string;
 };
@@ -15,6 +20,7 @@ export function PrerequisitesModal({
   open,
   onOpenChange,
   prerequisites,
+  todoPrerequisites,
   guideTitle,
   slug,
 }: PrerequisitesModalProps) {
@@ -24,7 +30,7 @@ export function PrerequisitesModal({
       onOpenChange={onOpenChange}
       title="Prerequisites"
       description="Guides worth reading before this one."
-      isEmpty={prerequisites.length === 0}
+      isEmpty={prerequisites.length + todoPrerequisites.length === 0}
       emptyIcon={<ListChecks className="h-6 w-6" />}
       emptyTitle="None declared"
       emptyDescription="This guide does not list any prerequisites."
@@ -47,6 +53,29 @@ export function PrerequisitesModal({
           <h4 className="text-xs font-bold text-foreground">{prereq.title}</h4>
           <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-all group-hover:translate-x-0.5 group-hover:text-foreground" />
         </Link>
+      ))}
+
+      {/* There's no guide to link to until the todo is resolved. */}
+      {todoPrerequisites.map((todo) => (
+        <div
+          key={todo.id}
+          className="flex w-full flex-col gap-1.5 rounded-lg border border-border bg-card p-3.5"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="min-w-0 text-xs font-bold break-words text-foreground">
+              {todo.title}
+            </h4>
+            <Badge
+              variant="outline"
+              className="border-transparent bg-brand-bright-blue/15 font-mono tracking-[0.06em] text-brand-dark-navy uppercase dark:text-brand-bright-blue"
+            >
+              Todo
+            </Badge>
+          </div>
+          <p className="text-xs break-words text-muted-foreground">
+            {todo.summary}
+          </p>
+        </div>
       ))}
     </BaseGuideModal>
   );

--- a/app/src/components/sidebar/GuideSidebar.tsx
+++ b/app/src/components/sidebar/GuideSidebar.tsx
@@ -1,11 +1,18 @@
 import { Link } from "@tanstack/react-router";
 import { useMemo } from "react";
-import type { Guide, GuideReference } from "@bluelearn/schemas";
+import type {
+  Guide,
+  GuideReference,
+  TodoPrerequisiteReference,
+} from "@bluelearn/schemas";
 import { CollapsibleSection } from "@/components/CollapsibleSection";
+import { Badge } from "@/components/ui/badge";
 import { extractHeadings } from "@/lib/guideUtils";
 
 type PropTypes = {
-  guide: Omit<Guide, "variant_id" | "is_official">;
+  guide: Omit<Guide, "variant_id" | "is_official" | "todo_prerequisites"> & {
+    todo_prerequisites?: Array<TodoPrerequisiteReference>;
+  };
   slug: string;
   sidebarActions?: React.ReactNode;
   reviewSection?: React.ReactNode;
@@ -23,6 +30,11 @@ export const GuideSidebar = ({
     () => extractHeadings(guide.body ?? ""),
     [guide.body]
   );
+
+  // Older API responses may not include todos during deployment.
+  const todoPrerequisites = guide.todo_prerequisites ?? [];
+  const prerequisiteCount =
+    guide.prerequisites.length + todoPrerequisites.length;
 
   return (
     <aside className="hidden px-6 py-6 md:sticky md:top-[65px] md:block md:h-[calc(100vh-65px)] md:self-start md:overflow-y-auto md:border-r">
@@ -61,7 +73,7 @@ export const GuideSidebar = ({
       {/* Prerequisites */}
       {showPrerequisites && (
         <CollapsibleSection defaultOpen={true} title="Prerequisites">
-          {guide.prerequisites.length === 0 ? (
+          {prerequisiteCount === 0 ? (
             <p
               className="text-xs text-muted-foreground"
               style={{ paddingLeft: 12 }}
@@ -89,6 +101,24 @@ export const GuideSidebar = ({
                   >
                     {prereq.title}
                   </Link>
+                </li>
+              ))}
+
+              {/* There's no guide to link to until the todo is resolved. */}
+              {todoPrerequisites.map((todo: TodoPrerequisiteReference) => (
+                <li
+                  key={todo.id}
+                  className="flex items-center gap-2 text-xs text-muted-foreground"
+                  style={{ paddingLeft: 12 }}
+                  title={todo.summary}
+                >
+                  <span className="min-w-0 break-words">{todo.title}</span>
+                  <Badge
+                    variant="outline"
+                    className="border-transparent bg-brand-bright-blue/15 font-mono tracking-[0.06em] text-brand-dark-navy uppercase dark:text-brand-bright-blue"
+                  >
+                    Todo
+                  </Badge>
                 </li>
               ))}
             </ul>

--- a/app/src/routes/guides/$slug/$variantSlug/edit.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/edit.tsx
@@ -162,6 +162,7 @@ function RouteComponent() {
         title: titleBySlug.get(slug) ?? slug,
       })),
       disclaimers: guideContData.disclaimers,
+      todo_prerequisites: [],
     };
   }, [
     guideContData,

--- a/app/src/routes/guides/$slug/$variantSlug/index.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/index.tsx
@@ -78,6 +78,7 @@ function RouteComponent() {
     tags: variant.tags,
     prerequisites: [],
     disclaimers: variant.disclaimers,
+    todo_prerequisites: [],
   };
 
   const guideMenuItems = [

--- a/app/src/routes/guides/$slug/$variantSlug/revisions.$revisionId.tsx
+++ b/app/src/routes/guides/$slug/$variantSlug/revisions.$revisionId.tsx
@@ -139,6 +139,7 @@ function RouteComponent() {
       tags: variant.tags,
       prerequisites: [],
       disclaimers: detail.disclaimers,
+      todo_prerequisites: [],
     };
 
     return (

--- a/app/src/routes/guides/$slug/index.tsx
+++ b/app/src/routes/guides/$slug/index.tsx
@@ -199,6 +199,7 @@ function RouteComponent() {
                 guideTitle={guide.title}
                 menuItems={guideMenuItems}
                 prerequisites={guide.prerequisites}
+                todoPrerequisites={guide.todo_prerequisites}
                 isOfficial={guide.is_official}
               />
 

--- a/app/src/routes/review.$caseId.tsx
+++ b/app/src/routes/review.$caseId.tsx
@@ -98,6 +98,7 @@ function RouteComponent() {
       tags: revision.tags,
       prerequisites: [],
       disclaimers: [],
+      todo_prerequisites: [],
     };
 
     return (

--- a/packages/schemas/src/guides/references.ts
+++ b/packages/schemas/src/guides/references.ts
@@ -8,3 +8,14 @@ export const guideReferenceSchema = z.object({
 });
 
 export type GuideReference = z.infer<typeof guideReferenceSchema>;
+
+// Requested prerequisites don't have a guide slug to link to yet.
+export const todoPrerequisiteReferenceSchema = z.object({
+  id: z.uuid(),
+  title: z.string(),
+  summary: z.string(),
+});
+
+export type TodoPrerequisiteReference = z.infer<
+  typeof todoPrerequisiteReferenceSchema
+>;

--- a/packages/schemas/src/guides/responses.ts
+++ b/packages/schemas/src/guides/responses.ts
@@ -13,7 +13,10 @@ import {
   revisionStatusSchema,
   voteDirectionSchema,
 } from "./enums";
-import { guideReferenceSchema } from "./references";
+import {
+  guideReferenceSchema,
+  todoPrerequisiteReferenceSchema,
+} from "./references";
 export const guideSchema = z.object({
   slug: z.string(),
   variant_id: z.string().nullable(),
@@ -27,6 +30,7 @@ export const guideSchema = z.object({
   created_at: z.iso.datetime({ offset: true }),
   tags: z.array(subjectReferenceSchema),
   prerequisites: z.array(guideReferenceSchema),
+  todo_prerequisites: z.array(todoPrerequisiteReferenceSchema),
   is_official: z.boolean(),
   disclaimers: z.array(disclaimerSchema),
 });


### PR DESCRIPTION
## Summary

Show requested prerequisites on guide pages with a Todo badge, including the
mobile prerequisites dialog. Guides with only todo prerequisites no longer
show "None declared."

The API returns open todos alongside existing prerequisites. Todos use the
same badge styling as the review sidebar and aren't clickable because there
isn't a guide to open yet. Long titles and summaries wrap within the layout.

This covers open todos only. Publishing a guide resolves the claimed todo but
doesn't create its prerequisite edge, so the released prerequisite still won't
appear unless an edge already exists. Would you prefer the release behavior
in this PR or a separate one?

(Closes #350)

## Type of change

- [x] Feature

## Verification

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r build` passes
- [ ] Manually verified in a browser (for UI / behavior changes)
- [x] Followed the app layout conventions
- [x] No new dependencies, or new dependencies are justified and AGPL-compatible
- [x] Change does not violate any non-negotiable principle

Lint, formatting on the changed files, 66 app tests, and the API deployment
dry-run pass. Nine new component tests cover empty, todo-only and mixed lists,
existing links, dialog closing, hidden variant prerequisites, and older API
responses without the new field.

I checked the actual components with sample data in a local browser preview:
desktop and mobile, light and dark mode, empty and mixed lists, and long text.
That doesn't cover the live API, so I've left the browser checkbox unchecked
until the full guide flow is verified.

The API integration test hasn't run yet because local Supabase isn't configured.
It checks sorting, empty results, open/resolved filtering, and that each guide
only gets its own todos while keeping its existing prerequisites.
